### PR TITLE
Upgrade JDBC driver to include RETURN clause detection fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-jdbc-bolt</artifactId>
-            <version>4.0.1</version>
+            <version>4.0.3</version>
             <scope>runtime</scope>
         </dependency>
 
@@ -120,6 +120,12 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>neo4j</artifactId>
             <version>1.16.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.neo4j.driver</groupId>
+            <artifactId>neo4j-java-driver</artifactId>
+            <version>4.3.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/liquibase/ext/neo4j/database/Neo4jDatabase.java
+++ b/src/main/java/liquibase/ext/neo4j/database/Neo4jDatabase.java
@@ -65,8 +65,10 @@ public class Neo4jDatabase extends AbstractJdbcDatabase {
     @Override
     public String getDefaultDriver(String url) {
         String connectionUrl = StringUtil.trimToEmpty(url);
-        if (connectionUrl.startsWith("jdbc:neo4j:bolt")
-                || connectionUrl.startsWith("jdbc:neo4j:neo4j")) {
+        if (connectionUrl.startsWith("jdbc:neo4j:neo4j") || connectionUrl.startsWith("jdbc:neo4j:bolt+routing")) {
+            return "org.neo4j.jdbc.boltrouting.BoltRoutingNeo4jDriver";
+        }
+        if (connectionUrl.startsWith("jdbc:neo4j:bolt")) {
             return "org.neo4j.jdbc.bolt.BoltDriver";
         }
         return null;

--- a/src/test/groovy/liquibase/ext/neo4j/database/Neo4jDatabaseTest.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/database/Neo4jDatabaseTest.groovy
@@ -55,10 +55,10 @@ class Neo4jDatabaseTest extends Specification {
         "jdbc:neo4j:bolt://localhost/"              | "org.neo4j.jdbc.bolt.BoltDriver"
         "jdbc:neo4j:bolt+s://localhost/"            | "org.neo4j.jdbc.bolt.BoltDriver"
         "jdbc:neo4j:bolt+ssc://localhost/"          | "org.neo4j.jdbc.bolt.BoltDriver"
-        "jdbc:neo4j:bolt+routing://localhost:1234/" | "org.neo4j.jdbc.bolt.BoltDriver"
-        "jdbc:neo4j:neo4j://localhost/"             | "org.neo4j.jdbc.bolt.BoltDriver"
-        "jdbc:neo4j:neo4j+s://localhost/"           | "org.neo4j.jdbc.bolt.BoltDriver"
-        "jdbc:neo4j:neo4j+ssc://localhost/"         | "org.neo4j.jdbc.bolt.BoltDriver"
+        "jdbc:neo4j:bolt+routing://localhost:1234/" | "org.neo4j.jdbc.boltrouting.BoltRoutingNeo4jDriver"
+        "jdbc:neo4j:neo4j://localhost/"             | "org.neo4j.jdbc.boltrouting.BoltRoutingNeo4jDriver"
+        "jdbc:neo4j:neo4j+s://localhost/"           | "org.neo4j.jdbc.boltrouting.BoltRoutingNeo4jDriver"
+        "jdbc:neo4j:neo4j+ssc://localhost/"         | "org.neo4j.jdbc.boltrouting.BoltRoutingNeo4jDriver"
         "jdbc:mysql://localhost/db"                 | null
         null                                        | null
     }


### PR DESCRIPTION
This also includes the support of the 4.x URI schemes and fixes
the JDBC driver instantiation when routing is needed.

Fixes #14