### PR TITLE
Update JDBC driver to include Netty fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-jdbc-bolt</artifactId>
-            <version>4.0.3</version>
+            <version>4.0.4</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
Note: this is not strictly required by this plugin.

This Netty fix allows CLI applications, relying only Connection
closes, to properly shut down without any explicit driver close
calls.

See https://github.com/neo4j-contrib/neo4j-jdbc/releases/tag/4.0.4
for details.