### PR TITLE
Reusable workflow build changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -383,58 +383,6 @@
                     </plugin>
 
                     <plugin>
-                        <groupId>org.jreleaser</groupId>
-                        <artifactId>jreleaser-maven-plugin</artifactId>
-                        <version>1.2.0</version>
-                        <configuration>
-                            <jreleaser>
-                                <project>
-                                    <name>liquibase-neo4j</name>
-                                    <version>${version.to.release}</version>
-                                    <copyright>Liquibase Inc.</copyright>
-                                </project>
-                                <release>
-                                    <github>
-                                        <update>
-                                            <enabled>true</enabled>
-                                            <sections>
-                                                <section>BODY</section>
-                                            </sections>
-                                        </update>
-                                        <skipTag>true</skipTag>
-                                        <tagName>liquibase-neo4j-{{projectVersion}}</tagName>
-                                        <releaseName>liquibase-neo4j-{{projectVersion}}</releaseName>
-                                        <changelog>
-                                            <preset>conventional-commits</preset>
-                                            <formatted>ALWAYS</formatted>
-                                            <labelers>
-                                                <labeler>
-                                                    <label>liquibot</label>
-                                                    <title>regex:(Version Bumped to.*|.*next release.*)</title>
-                                                </labeler>
-                                            </labelers>
-                                            <categories>
-                                                <category>
-                                                    <title>ignored</title>
-                                                    <key>liquibot</key>
-                                                    <labels>liquibot</labels>
-                                                </category>
-                                            </categories>
-                                            <hide>
-                                                <categories>liquibot</categories>
-                                                <contributors>
-                                                    <contributor>GitHub</contributor>
-                                                    <contributor>bot</contributor>
-                                                </contributors>
-                                            </hide>
-                                        </changelog>
-                                    </github>
-                                </release>
-                            </jreleaser>
-                        </configuration>
-                    </plugin>
-
-                    <plugin>
                         <groupId>com.coderplus.maven.plugins</groupId>
                         <artifactId>copy-rename-maven-plugin</artifactId>
                         <version>1.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,12 @@
         <profile>
             <!-- Required for deployment to Sonatype -->
             <id>release</id>
+            <activation>
+                <property>
+                    <name>env.CI</name>
+                    <value>true</value>
+                </property>
+            </activation>
             <build>
                 <plugins>
 

--- a/pom.xml
+++ b/pom.xml
@@ -428,6 +428,29 @@
                         </configuration>
                     </plugin>
 
+                    <plugin>
+                        <groupId>com.coderplus.maven.plugins</groupId>
+                        <artifactId>copy-rename-maven-plugin</artifactId>
+                        <version>1.0</version>
+                        <executions>
+                            <execution>
+                                <id>copy</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <fileSets>
+                                        <fileSet>
+                                            <sourceFile>${project.basedir}/pom.xml</sourceFile>
+                                            <destinationFile>${project.basedir}/target/${project.artifactId}-${project.version}.pom</destinationFile>
+                                        </fileSet>
+                                    </fileSets>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
                 </plugins>
             </build>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -369,7 +369,7 @@
                             <quiet>true</quiet>
                             <doclint>none</doclint>
                             <encoding>UTF-8</encoding>
-                            <jarOutputDirectory>${project.basedir}/target</jarOutputDirectory>
+                            <jarOutputDirectory>${project.build.directory}</jarOutputDirectory>
                         </configuration>
                         <executions>
                             <execution>
@@ -397,7 +397,7 @@
                                     <fileSets>
                                         <fileSet>
                                             <sourceFile>${project.basedir}/pom.xml</sourceFile>
-                                            <destinationFile>${project.basedir}/target/${project.artifactId}-${project.version}.pom</destinationFile>
+                                            <destinationFile>${project.build.directory}/${project.artifactId}-${project.version}.pom</destinationFile>
                                         </fileSet>
                                     </fileSets>
                                 </configuration>


### PR DESCRIPTION
- copy pom to target folder during release build
- activate the release profile when building on GHA

Note: I am making these changes to support the reusable workflows effort that is being led by @mcred and @jnewton03 . I don't have the required context to know whether the changes I'm making here constitute "best practices" as far as this plugin is concerned. Perhaps there is a better way to do what I'm doing here.