### PR TITLE
Work around the priorization of change class selection in core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
         <sonar.qualitygate.wait>true</sonar.qualitygate.wait>
         <sonar.sources>src/main/java</sonar.sources>
         <sonar.tests>src/test/groovy</sonar.tests>
+        <testcontainers.version>1.18.3</testcontainers.version>
     </properties>
 
     <dependencies>
@@ -108,7 +109,19 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>neo4j</artifactId>
-            <version>1.18.3</version>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.0.33</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/liquibase/ext/neo4j/change/InsertNodeChange.java
+++ b/src/main/java/liquibase/ext/neo4j/change/InsertNodeChange.java
@@ -23,28 +23,23 @@ import static liquibase.ext.neo4j.change.ColumnMapper.mapValue;
         description = "Inserts a node to the graph")
 public class InsertNodeChange extends InsertDataChange {
 
-    private String labelName = "";
+    private String labelName;
 
     @Override
     public boolean supports(Database database) {
-        return database instanceof Neo4jDatabase;
+        return database instanceof Neo4jDatabase || super.supports(database);
     }
 
     @Override
     public ValidationErrors validate(Database database) {
+        if (!(database instanceof Neo4jDatabase)) {
+            return super.validate(database);
+        }
         ValidationErrors errors = new ValidationErrors(this);
         if (Sequences.isNullOrEmpty(labelName)) {
             errors.addError("label name for insert must be specified and not blank");
         }
         return errors;
-    }
-
-    public void setLabelName(String labelName) {
-        this.setTableName(labelName);
-    }
-
-    public String getLabelName() {
-        return labelName;
     }
 
     @Override
@@ -55,6 +50,9 @@ public class InsertNodeChange extends InsertDataChange {
 
     @Override
     public SqlStatement[] generateStatements(Database database) {
+        if (!(database instanceof Neo4jDatabase)) {
+            return super.generateStatements(database);
+        }
         return new SqlStatement[]{
                 new RawParameterizedSqlStatement(
                         String.format("CREATE (node:`%s`) SET node = $0", this.getTableName()),
@@ -68,6 +66,14 @@ public class InsertNodeChange extends InsertDataChange {
         Set<String> fields = new HashSet<>(super.getSerializableFields());
         fields.remove("tableName");
         return fields;
+    }
+
+    public void setLabelName(String labelName) {
+        this.setTableName(labelName);
+    }
+
+    public String getLabelName() {
+        return labelName;
     }
 
     private Map<String, Object> propertyMap(List<ColumnConfig> columns) {

--- a/src/main/java/liquibase/ext/neo4j/change/LoadGraphDataChange.java
+++ b/src/main/java/liquibase/ext/neo4j/change/LoadGraphDataChange.java
@@ -44,11 +44,14 @@ public class LoadGraphDataChange extends LoadDataChange {
 
     @Override
     public boolean supports(Database database) {
-        return database instanceof Neo4jDatabase;
+        return database instanceof Neo4jDatabase || super.supports(database);
     }
 
     @Override
     protected SqlStatement[] generateStatementsFromRows(Database database, List<LoadDataRowConfig> rows) {
+        if (!(database instanceof Neo4jDatabase)) {
+            return super.generateStatementsFromRows(database, rows);
+        }
         String cypher = String.format("UNWIND $0 AS row CREATE (n:`%s`) SET n += row", escapeLabel(getTableName()));
         return new SqlStatement[]{new RawParameterizedSqlStatement(cypher, keyValuePairs(rows))};
     }

--- a/src/test/groovy/liquibase/ext/neo4j/Neo4jContainerSpec.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/Neo4jContainerSpec.groovy
@@ -96,7 +96,7 @@ abstract class Neo4jContainerSpec extends Specification {
         return dockerTag()
     }
 
-    private static PrintStream tempFilePrintStream() {
+    static PrintStream tempFilePrintStream() {
         new PrintStream(Files.createTempFile("liquibase", "neo4j").toFile())
     }
 }

--- a/src/test/groovy/liquibase/ext/neo4j/change/InsertNodeChangeTest.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/change/InsertNodeChangeTest.groovy
@@ -6,15 +6,13 @@ import spock.lang.Specification
 
 class InsertNodeChangeTest extends Specification {
 
-    def "supports only Neo4j targets"() {
+    def "supports Neo4j targets"() {
         expect:
         new InsertNodeChange().supports(database) == result
 
         where:
         database            | result
         new Neo4jDatabase() | true
-        null                | false
-        new MySQLDatabase() | false
     }
 
     def "requires label name to be set"() {

--- a/src/test/groovy/liquibase/ext/neo4j/change/LoadGraphDataChangeTest.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/change/LoadGraphDataChangeTest.groovy
@@ -1,20 +1,16 @@
 package liquibase.ext.neo4j.change
 
-import liquibase.database.core.MySQLDatabase
 import liquibase.ext.neo4j.database.Neo4jDatabase
 import spock.lang.Specification
 
 class LoadGraphDataChangeTest extends Specification {
 
-
-    def "supports only Neo4j targets"() {
+    def "supports Neo4j targets"() {
         expect:
         new LoadGraphDataChange().supports(database) == result
 
         where:
         database            | result
         new Neo4jDatabase() | true
-        null                | false
-        new MySQLDatabase() | false
     }
 }

--- a/src/test/groovy/liquibase/ext/neo4j/e2e/MySQLMigrationIT.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/e2e/MySQLMigrationIT.groovy
@@ -1,0 +1,64 @@
+package liquibase.ext.neo4j.e2e
+
+import liquibase.command.CommandScope
+import liquibase.command.core.UpdateCommandStep
+import liquibase.command.core.helpers.DatabaseChangelogCommandStep
+import liquibase.command.core.helpers.DbUrlConnectionCommandStep
+import org.testcontainers.containers.MySQLContainer
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.sql.Connection
+import java.sql.DriverManager
+
+import static liquibase.ext.neo4j.Neo4jContainerSpec.tempFilePrintStream
+
+class MySQLMigrationIT extends Specification {
+
+    @Shared
+    def mysql = new MySQLContainer<>("mysql:8")
+
+    @Shared
+    Connection connection
+
+    def setupSpec() {
+        System.out = tempFilePrintStream()
+        System.err = tempFilePrintStream()
+        mysql.start()
+        connection = DriverManager.getConnection(mysql.getJdbcUrl(), mysql.getUsername(), mysql.getPassword())
+    }
+
+    def cleanupSpec() {
+        connection.close()
+        mysql.stop()
+    }
+
+    def "runs migrations for MySQL without interference from the Neo4j plugin"() {
+        when:
+        def command = new CommandScope(UpdateCommandStep.COMMAND_NAME)
+                .addArgumentValue(DbUrlConnectionCommandStep.URL_ARG, mysql.getJdbcUrl())
+                .addArgumentValue(DbUrlConnectionCommandStep.USERNAME_ARG, mysql.getUsername())
+                .addArgumentValue(DbUrlConnectionCommandStep.PASSWORD_ARG, mysql.getPassword())
+                .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, "/e2e/mysql/changeLog.xml")
+                .setOutput(System.out)
+        command.execute()
+
+        then:
+        connection.createStatement()
+                .withCloseable {
+                    it.executeQuery("SELECT name FROM first_names ORDER BY name ASC")
+                    .withCloseable {
+                        assert it.next()
+                        assert it.getString("name") == "Florent"
+                        assert it.next()
+                        assert it.getString("name") == "Marouane"
+                        assert it.next()
+                        assert it.getString("name") == "Nathan"
+                        assert it.next()
+                        assert it.getString("name") == "Robert"
+                        assert !it.next()
+                    }
+                    return true
+                }
+    }
+}

--- a/src/test/resources/e2e/mysql/changeLog.xml
+++ b/src/test/resources/e2e/mysql/changeLog.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="names-init" author="fbiville">
+        <createTable tableName="first_names">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="name" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet id="names-import" author="fbiville">
+        <loadData file="e2e/mysql/names.csv" tableName="first_names">
+            <column name="name" header="name" type="varchar"/>
+        </loadData>
+    </changeSet>
+
+    <changeSet id="names-import-bis" author="fbiville">
+        <insert tableName="first_names">
+            <column name="name" value="Robert"/>
+        </insert>
+        <insert tableName="first_names">
+            <column name="name" value="Marouane"/>
+        </insert>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/resources/e2e/mysql/names.csv
+++ b/src/test/resources/e2e/mysql/names.csv
@@ -1,0 +1,3 @@
+name
+Florent
+Nathan


### PR DESCRIPTION
Database-specific change subclasses (like
`liquibase.ext.neo4j.change.LoadGraphDataChange` or `liquibase.ext.neo4j.change.InsertNodeChange`) can interfere with executions not targeting Neo4j.

The reason for this behavior is that
`liquibase.change.ChangeFactory#create` selects a particular class for a given change, only based on the class' declared priority.

The two above changes declare a `PRIORITY_DATABASE`, which means they have higher priority than the built-in changes.

When Neo4j is in the classpath, this means these classes can get picked up, even though:

 - a completely different DBMS is configured at execution time
 - `liquibase.change.Change#supports` is properly implemented

If any of the overridden methods implement Neo4j-specific behavior ( Cypher queries e.g.), this leads to execution failures.

A more subtle failure that occurs is when extra fields are introduced by the subclass (like `InsertNodeChange` and its field `labelName`) and are initialized with non-default values.
What happens is that the checksum value changes and becomes incompatible with what was stored in the target database.

The only viable fix is to cater for non-Neo4j databases. When a non-Neo4j database is encountered, call the parent class implementation instead of running the Neo4j-specific implementation. This works as long as other extensions in the classpath do not also subclass the same parent class.

Fixes https://github.com/liquibase/liquibase-neo4j/issues/413