### PR TITLE
Fix incomplete implementation of JDBC autocommit

### DIFF
--- a/src/test/groovy/liquibase/ext/neo4j/database/jdbc/Neo4jConnectionIT.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/database/jdbc/Neo4jConnectionIT.groovy
@@ -1,0 +1,27 @@
+package liquibase.ext.neo4j.database.jdbc
+
+import liquibase.ext.neo4j.Neo4jContainerSpec
+
+class Neo4jConnectionIT extends Neo4jContainerSpec {
+
+    def "commits the explicit transaction when switching to autocommit"() {
+        when:
+        def connection = (Neo4jConnection) new Neo4jDriver().connect(jdbcUrl(), authenticationProperties())
+        connection.setAutoCommit(false)
+        assert !connection.getAutoCommit()
+        def statement = connection.prepareStatement("RETURN 42")
+        statement.executeQuery()
+        def transaction = connection.getTransaction()
+        assert transaction.isOpen()
+
+        and:
+        connection.setAutoCommit(true)
+        assert connection.getAutoCommit()
+
+        then:
+        !transaction.isOpen()
+
+        cleanup:
+        connection.close()
+    }
+}

--- a/src/test/groovy/liquibase/ext/neo4j/database/jdbc/Neo4jConnectionTest.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/database/jdbc/Neo4jConnectionTest.groovy
@@ -1,6 +1,6 @@
 package liquibase.ext.neo4j.database.jdbc
 
-
+import org.neo4j.driver.Transaction
 import spock.lang.Specification
 
 import java.sql.Connection
@@ -18,10 +18,18 @@ import static liquibase.ext.neo4j.database.jdbc.ResultSets.rsTypeName
 
 class Neo4jConnectionTest extends Specification {
 
-    Connection connection
+    Neo4jConnection connection
 
     def setup() {
         connection = new Neo4jConnection("jdbc:neo4j:neo4j://example.com", new Properties())
+    }
+
+    def "new connections are in autocommit mode by default"() {
+        when:
+        connection = new Neo4jConnection("jdbc:neo4j:neo4j://example.com", new Properties())
+
+        then:
+        connection.getAutoCommit()
     }
 
     def "creates a simple statement"() {

--- a/src/test/groovy/liquibase/ext/neo4j/database/jdbc/Neo4jConnectionTest.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/database/jdbc/Neo4jConnectionTest.groovy
@@ -4,6 +4,7 @@ import org.neo4j.driver.Transaction
 import spock.lang.Specification
 
 import java.sql.Connection
+import java.sql.SQLException
 
 import static java.sql.ResultSet.CLOSE_CURSORS_AT_COMMIT
 import static java.sql.ResultSet.CONCUR_READ_ONLY
@@ -162,5 +163,23 @@ but got:
         false      | TYPE_SCROLL_SENSITIVE   | CONCUR_READ_ONLY | CLOSE_CURSORS_AT_COMMIT
         false      | TYPE_SCROLL_SENSITIVE   | CONCUR_UPDATABLE | HOLD_CURSORS_OVER_COMMIT
         false      | TYPE_SCROLL_SENSITIVE   | CONCUR_UPDATABLE | CLOSE_CURSORS_AT_COMMIT
+    }
+
+    def "fails to commit in autocommit mode"() {
+        when:
+        connection.commit()
+
+        then:
+        def exception = thrown(SQLException.class)
+        exception.message == "the connection is in auto-commit mode. Explicit commit is prohibited"
+    }
+
+    def "fails to rollback in autocommit mode"() {
+        when:
+        connection.rollback()
+
+        then:
+        def exception = thrown(SQLException.class)
+        exception.message == "the connection is in auto-commit mode. Explicit rollback is prohibited"
     }
 }

--- a/src/test/groovy/liquibase/ext/neo4j/database/jdbc/Neo4jStatementIT.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/database/jdbc/Neo4jStatementIT.groovy
@@ -29,6 +29,7 @@ class Neo4jStatementIT extends Neo4jContainerSpec {
     def "can rollback simple statement, execute it again and then commit"() {
         given:
         def connection = new Neo4jDriver().connect(jdbcUrl(), authenticationProperties())
+        connection.setAutoCommit(false)
         def statement = connection.createStatement()
 
         when:
@@ -92,6 +93,7 @@ class Neo4jStatementIT extends Neo4jContainerSpec {
     def "can rollback parameterized statement, execute it again and then commit"() {
         given:
         def connection = new Neo4jDriver().connect(jdbcUrl(), authenticationProperties())
+        connection.setAutoCommit(false)
         def statement = connection.prepareStatement("MERGE (c:Count) ON CREATE SET c.count = \$1 ON MATCH SET c.count = c.count+1 RETURN c.count AS count")
 
         when:


### PR DESCRIPTION
Connections must set to autocommit mode by default.

If an explicit transaction is open and the connection switches to autocommit, that explicit transaction must be committed.

This should have no impact on Liquibase users.