### PR TITLE
fix: liquibase-commercial should not be added to the uber jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-commercial</artifactId>
+            <version>${liquibase.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.neo4j.driver</groupId>
             <artifactId>neo4j-java-driver</artifactId>
             <version>${neo4j-driver.version}</version>


### PR DESCRIPTION
Liquibase-commercial should not be added to the uber jar as it may conflicts with liquibase-commercial distributed with liquibase.