### PR TITLE
Fix for mixing manual/auto transaction modes in same migration run

### DIFF
--- a/src/main/java/liquibase/ext/neo4j/database/jdbc/Neo4jConnection.java
+++ b/src/main/java/liquibase/ext/neo4j/database/jdbc/Neo4jConnection.java
@@ -87,7 +87,7 @@ class Neo4jConnection implements Connection, DatabaseMetaData {
         if (this.autocommit == autoCommit) {
             return;
         }
-        if (this.transaction != null) {
+        if (this.transaction != null && transaction.isOpen()) {
             this.commit();
         }
         this.autocommit = autoCommit;

--- a/src/test/groovy/liquibase/ext/neo4j/e2e/AutocommitIT.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/e2e/AutocommitIT.groovy
@@ -11,22 +11,6 @@ import static liquibase.ext.neo4j.DockerNeo4j.supportsCypherCallInTransactions
 
 class AutocommitIT extends Neo4jContainerSpec {
 
-    private fetchRow() {
-        return queryRunner.getSingleRow("""
-            MATCH (n)
-            WHERE none(label IN labels(n) WHERE label STARTS WITH "__Liquibase")
-            UNWIND labels(n) AS label 
-            WITH n, label
-            ORDER BY label ASC
-            WITH n, collect(label) AS labels
-            UNWIND keys(n) AS key
-            WITH n, labels, {k: key, v: n[key]} AS property
-            ORDER BY labels ASC, key ASC, n[key] ASC
-            OPTIONAL MATCH (n)-[r]-()
-            RETURN labels, collect(property) AS properties, count(r) AS rel_count
-        """)
-    }
-
     @Requires({ supportsCypherCallInTransactions() })
     def "runs autocommit transaction"() {
         given:
@@ -52,13 +36,13 @@ class AutocommitIT extends Neo4jContainerSpec {
     }
 
     @Requires({ supportsCypherCallInTransactions() })
-    def "runs autocommit transactions mixed with manual transactions"() {
+    def "runs autocommit transactions mixed with default explicit transactions"() {
         given:
         def command = new CommandScope(UpdateCommandStep.COMMAND_NAME)
                 .addArgumentValue(DbUrlConnectionCommandStep.URL_ARG, "jdbc:neo4j:${neo4jContainer.getBoltUrl()}".toString())
                 .addArgumentValue(DbUrlConnectionCommandStep.USERNAME_ARG, "neo4j")
                 .addArgumentValue(DbUrlConnectionCommandStep.PASSWORD_ARG, PASSWORD)
-                .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, "/e2e/autocommit/changeLogMixed.xml".toString())
+                .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, "/e2e/autocommit/changeLog-mixed.${format}".toString())
                 .setOutput(System.out)
         command.execute()
 
@@ -70,5 +54,24 @@ class AutocommitIT extends Neo4jContainerSpec {
                 properties: [[k: "genre", v: "Drama"], [k: "title", v: "My Life 2"]],
                 rel_count : 0
         ]
+
+        where:
+        format << ["cypher", "json", "xml", "yaml"]
+    }
+
+    private fetchRow() {
+        return queryRunner.getSingleRow("""
+            MATCH (n)
+            WHERE none(label IN labels(n) WHERE label STARTS WITH "__Liquibase")
+            UNWIND labels(n) AS label
+            WITH n, label
+            ORDER BY label ASC
+            WITH n, collect(label) AS labels
+            UNWIND keys(n) AS key
+            WITH n, labels, {k: key, v: n[key]} AS property
+            ORDER BY labels ASC, key ASC, n[key] ASC
+            OPTIONAL MATCH (n)-[r]-()
+            RETURN labels, collect(property) AS properties, count(r) AS rel_count
+        """)
     }
 }

--- a/src/test/resources/e2e/autocommit/changeLog-mixed.cypher
+++ b/src/test/resources/e2e/autocommit/changeLog-mixed.cypher
@@ -1,0 +1,10 @@
+-- liquibase formatted sql
+
+-- changeset hindog:my-movie-init runInTransaction:false
+CALL { CREATE (:Movie {title: 'My Life', genre: 'Comedy'}) } IN TRANSACTIONS
+
+-- changeset hindog:my-movie-set-drama
+MATCH (m:Movie {title: 'My Life', genre: 'Comedy'}) SET m.genre = 'Drama'
+
+-- changeset hindog:my-movie-set-title runInTransaction:false
+CALL { MATCH (m:Movie {title: 'My Life', genre: 'Drama'}) SET m.title = 'My Life 2' } IN TRANSACTIONS

--- a/src/test/resources/e2e/autocommit/changeLog-mixed.json
+++ b/src/test/resources/e2e/autocommit/changeLog-mixed.json
@@ -1,0 +1,39 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "my-movie-init",
+        "author": "hindog",
+        "runInTransaction": false,
+        "changes": [
+          {
+            "cypher": "CALL { CREATE (:Movie {title: 'My Life', genre: 'Comedy'}) } IN TRANSACTIONS"
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "my-movie-set-drama",
+        "author": "hindog",
+        "changes": [
+          {
+            "cypher": "MATCH (m:Movie {title: 'My Life', genre: 'Comedy'}) SET m.genre = 'Drama'"
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "my-movie-set-title",
+        "author": "hindog",
+        "runInTransaction": false,
+        "changes": [
+          {
+            "cypher": "CALL { MATCH (m:Movie {title: 'My Life', genre: 'Drama'}) SET m.title = 'My Life 2' } IN TRANSACTIONS"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/resources/e2e/autocommit/changeLog-mixed.xml
+++ b/src/test/resources/e2e/autocommit/changeLog-mixed.xml
@@ -3,15 +3,15 @@
                    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
-    <changeSet id="my-movie-init" author="fbiville" runInTransaction="false">
+    <changeSet id="my-movie-init" author="hindog" runInTransaction="false">
         <sql>CALL { CREATE (:Movie {title: 'My Life', genre: 'Comedy'}) } IN TRANSACTIONS</sql>
     </changeSet>
 
-    <changeSet id="my-movie-set-drama" author="fbiville">
+    <changeSet id="my-movie-set-drama" author="hindog">
         <sql>MATCH (m:Movie {title: 'My Life', genre: 'Comedy'}) SET m.genre = 'Drama'</sql>
     </changeSet>
 
-    <changeSet id="my-movie-set-title" author="fbiville" runInTransaction="false">
+    <changeSet id="my-movie-set-title" author="hindog" runInTransaction="false">
         <sql>CALL { MATCH (m:Movie {title: 'My Life', genre: 'Drama'}) SET m.title = 'My Life 2' } IN TRANSACTIONS</sql>
     </changeSet>
 

--- a/src/test/resources/e2e/autocommit/changeLog-mixed.yaml
+++ b/src/test/resources/e2e/autocommit/changeLog-mixed.yaml
@@ -1,0 +1,18 @@
+databaseChangeLog:
+  - changeSet:
+      id: my-movie-init
+      author: hindog
+      runInTransaction: false
+      changes:
+        - cypher: 'CALL { CREATE (:Movie {title: ''My Life'', genre: ''Comedy''}) } IN TRANSACTIONS'
+  - changeSet:
+      id: my-movie-set-drama
+      author: hindog
+      changes:
+        - cypher: 'MATCH (m:Movie {title: ''My Life'', genre: ''Comedy''}) SET m.genre = ''Drama'''
+  - changeSet:
+      id: my-movie-set-title
+      author: hindog
+      runInTransaction: false
+      changes:
+        - cypher: 'CALL { MATCH (m:Movie {title: ''My Life'', genre: ''Drama''}) SET m.title = ''My Life 2'' } IN TRANSACTIONS'

--- a/src/test/resources/e2e/autocommit/changeLogMixed.xml
+++ b/src/test/resources/e2e/autocommit/changeLogMixed.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="my-movie-init" author="fbiville" runInTransaction="false">
+        <sql>CALL { CREATE (:Movie {title: 'My Life', genre: 'Comedy'}) } IN TRANSACTIONS</sql>
+    </changeSet>
+
+    <changeSet id="my-movie-set-drama" author="fbiville">
+        <sql>MATCH (m:Movie {title: 'My Life', genre: 'Comedy'}) SET m.genre = 'Drama'</sql>
+    </changeSet>
+
+    <changeSet id="my-movie-set-title" author="fbiville" runInTransaction="false">
+        <sql>CALL { MATCH (m:Movie {title: 'My Life', genre: 'Drama'}) SET m.title = 'My Life 2' } IN TRANSACTIONS</sql>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
When running consecutive `ChangeSet`'s that use different transaction modes (`runInTransaction=true|false`), the migration will fail with an Exception with the following message:

```
the connection is in auto-commit mode. Explicit commit is prohibited
```

Specifically, if we run one `ChangeSet` with `runInTransaction=false (ie: setAutoCommit(true))` and another with `runInTransaction=true`, then this bug will be triggered. 

The problem appears to be in [Neo4jConnection.java#setAutoCommit](https://github.com/liquibase/liquibase-neo4j/blob/main/src/main/java/liquibase/ext/neo4j/database/jdbc/Neo4jConnection.java#L86):

```java
    @Override
    public void setAutoCommit(boolean autoCommit) throws SQLException {
        if (this.autocommit == autoCommit) {
            return;
        }
        if (this.transaction != null) {  // <-- transaction is non-null and contains the previous transaction which has already been committed
            this.commit();
        }
        this.autocommit = autoCommit;
    }

   /* ... omitted ... */ 
   
   @Override
    public void commit() throws SQLException {
        if (autocommit) {   // <-- and this will immediately throw an exception
            throw new SQLException("the connection is in auto-commit mode. Explicit commit is prohibited");
        }
        if (!transaction.isOpen()) {
            return;
        }
        transaction.commit();
        transaction.close();
    }
```

I tested this patch against my failing migrations and the issue was fixed