### PR TITLE
use authorize step for external users

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,14 @@ on:
       - 'docs/**'
 
 jobs:
+  authorize:
+    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+      
   build-test:
+    needs: authorize
     uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.7.7
     secrets: inherit
 


### PR DESCRIPTION
fix: `.github/workflows/test.yml`: use authorize workflow before approving external PR for the workflows to run