### PR TITLE
use authorize for external jobs 

### DIFF
--- a/.github/workflows/test-5x-driver.yml
+++ b/.github/workflows/test-5x-driver.yml
@@ -2,7 +2,7 @@ name: Build and Test with 5.x Neo4j Java driver
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened
@@ -14,7 +14,14 @@ on:
       - 'docs/**'
 
 jobs:
+  authorize:
+    environment: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: true
+        
   build-test:
+    needs: authorize
     uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.7.7
     secrets: inherit
 


### PR DESCRIPTION
fix: `.github/workflows/test-5x-driver.yml`:  use authorize workflow before approving external PR for the workflows to run