### PR TITLE
Work around regression introduced in core 4.29.2

### DIFF
--- a/src/main/java/liquibase/ext/neo4j/change/LoadGraphDataChange.java
+++ b/src/main/java/liquibase/ext/neo4j/change/LoadGraphDataChange.java
@@ -10,6 +10,7 @@ import liquibase.statement.SqlStatement;
 import liquibase.statement.core.RawParameterizedSqlStatement;
 
 import java.util.AbstractMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -58,7 +59,10 @@ public class LoadGraphDataChange extends LoadDataChange {
                 .map(row -> row.getColumns().stream()
                         .flatMap(LoadGraphDataChange::keyValuePair)
                         .collect(toMap(Map.Entry::getKey, Map.Entry::getValue)))
-                .collect(Collectors.toList());
+                // note: this is explicitly NOT using an ArrayList because of a regression introduced in core v4.29.2
+                // (see commit 631b7d42dd32d67f59f8294dc40d20d3c01085ab, JdbcExecutor#setParameters)
+                // ArrayList parameters get flattened instead of being treated as a whole list
+                .collect(Collectors.toCollection(LinkedList::new));
     }
 
     private static Stream<AbstractMap.SimpleEntry<String, Object>> keyValuePair(LoadDataColumnConfig column) {


### PR DESCRIPTION
[This commit](https://github.com/liquibase/liquibase/commit/631b7d42dd32d67f59f8294dc40d20d3c01085ab#diff-57b8a969c50e3c98da190e27b6887f88de5466091cf62518775f6fda91ce008bR191-R206) merged in core makes it so that parameters passed as `ArrayList` get flattened to individual parameters, which breaks internal prepared statements in `loadData` and `mergeNodes`.

The workaround consists in using another `List` type which is not handled by the code linked above.