### PR TITLE
Improve label and type rename for users of Neo4j >= 5.26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,7 @@
     </dependencies>
 
     <build>
+        <defaultGoal>verify</defaultGoal>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/liquibase/ext/neo4j/change/BatchableChange.java
+++ b/src/main/java/liquibase/ext/neo4j/change/BatchableChange.java
@@ -37,22 +37,23 @@ abstract class BatchableChange extends AbstractChange {
     @Override
     public SqlStatement[] generateStatements(Database database) {
         Logger log = Scope.getCurrentScope().getLog(getClass());
-        boolean supportsCallInTransactions = ((Neo4jDatabase) database).supportsCallInTransactions();
+        Neo4jDatabase neo4j = (Neo4jDatabase) database;
+        boolean supportsCallInTransactions = neo4j.supportsCallInTransactions();
         if (supportsCallInTransactions && enableBatchImport) {
             log.info("Running change in CALL {} IN TRANSACTIONS");
-            return generateBatchedStatements(database);
+            return generateBatchedStatements(neo4j);
         } else if (!supportsCallInTransactions) {
-            log.warning("This version of Neo4j does not support CALL {} IN TRANSACTIONS, the type rename is going to run in a single, possibly large and slow, transaction.\n" +
+            log.warning("This version of Neo4j does not support CALL {} IN TRANSACTIONS, the change is going to run in a single, possibly large and slow, transaction.\n" +
                     "Note: upgrade the Neo4j server or set the runInTransaction attribute of the enclosing change set to true to make this warning disappear.");
         } else {
-            log.info("Running type rename in single transaction (set enableBatchImport to true to switch to CALL {} IN TRANSACTIONS)");
+            log.info("Running change in single transaction (set enableBatchImport to true to switch to CALL {} IN TRANSACTIONS)");
         }
-        return generateUnbatchedStatements(database);
+        return generateUnbatchedStatements(neo4j);
     }
 
-    protected abstract SqlStatement[] generateBatchedStatements(Database database);
+    protected abstract SqlStatement[] generateBatchedStatements(Neo4jDatabase database);
 
-    protected abstract SqlStatement[] generateUnbatchedStatements(Database database);
+    protected abstract SqlStatement[] generateUnbatchedStatements(Neo4jDatabase database);
 
 
     public Boolean getEnableBatchImport() {

--- a/src/main/java/liquibase/ext/neo4j/change/InvertDirectionChange.java
+++ b/src/main/java/liquibase/ext/neo4j/change/InvertDirectionChange.java
@@ -57,7 +57,7 @@ public class InvertDirectionChange extends BatchableChange {
         return String.format("the direction of relationships with type %s has been inverted", type);    }
 
     @Override
-    protected SqlStatement[] generateBatchedStatements(Database database) {
+    protected SqlStatement[] generateBatchedStatements(Neo4jDatabase database) {
         String cypher = String.format("%s " +
                 "CALL { " +
                 "   WITH __rel__ " +
@@ -71,7 +71,7 @@ public class InvertDirectionChange extends BatchableChange {
     }
 
     @Override
-    protected SqlStatement[] generateUnbatchedStatements(Database database) {
+    protected SqlStatement[] generateUnbatchedStatements(Neo4jDatabase database) {
         String cypher = String.format("%s " +
                 "MATCH (__start__) WHERE id(__start__) = id(startNode(__rel__)) " +
                 "MATCH (__end__) WHERE id(__end__) = id(endNode(__rel__)) " +

--- a/src/main/java/liquibase/ext/neo4j/change/RenamePropertyChange.java
+++ b/src/main/java/liquibase/ext/neo4j/change/RenamePropertyChange.java
@@ -59,7 +59,7 @@ public class RenamePropertyChange extends BatchableChange {
     }
 
     @Override
-    protected SqlStatement[] generateBatchedStatements(Database database) {
+    protected SqlStatement[] generateBatchedStatements(Neo4jDatabase database) {
         String batchSpec = cypherBatchSpec();
         String nodeRename = String.format("MATCH (n) WHERE n[$1] IS NOT NULL CALL { WITH n SET n.`%2$s` = n[$1] REMOVE n.`%1$s` } IN TRANSACTIONS%3$s", from, to, batchSpec);
         String relRename = String.format("MATCH ()-[r]->() WHERE r[$1] IS NOT NULL CALL { WITH r SET r.`%2$s` = r[$1] REMOVE r.`%1$s` } IN TRANSACTIONS%3$s", from, to, batchSpec);
@@ -67,7 +67,7 @@ public class RenamePropertyChange extends BatchableChange {
     }
 
     @Override
-    protected SqlStatement[] generateUnbatchedStatements(Database database) {
+    protected SqlStatement[] generateUnbatchedStatements(Neo4jDatabase database) {
         String nodeRename = String.format("MATCH (n) WHERE n[$1] IS NOT NULL SET n.`%2$s` = n[$1] REMOVE n.`%1$s` ", from, to);
         String relRename = String.format("MATCH ()-[r]->() WHERE r[$1] IS NOT NULL SET r.`%2$s` = r[$1] REMOVE r.`%1$s`", from, to);
         return filterStatements(nodeRename, relRename);

--- a/src/main/java/liquibase/ext/neo4j/change/RenameTypeChange.java
+++ b/src/main/java/liquibase/ext/neo4j/change/RenameTypeChange.java
@@ -1,28 +1,20 @@
 package liquibase.ext.neo4j.change;
 
-import liquibase.Scope;
-import liquibase.change.AbstractChange;
 import liquibase.change.ChangeMetaData;
 import liquibase.change.DatabaseChange;
 import liquibase.database.Database;
 import liquibase.exception.ValidationErrors;
-import liquibase.ext.neo4j.change.Sequences;
 import liquibase.ext.neo4j.database.Neo4jDatabase;
-import liquibase.logging.Logger;
 import liquibase.statement.SqlStatement;
 import liquibase.statement.core.RawParameterizedSqlStatement;
-import liquibase.statement.core.RawSqlStatement;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import static liquibase.ext.neo4j.database.KernelVersion.V5_24_0;
+import static liquibase.ext.neo4j.database.KernelVersion.V5_26_0;
 
 @DatabaseChange(name = "renameType", priority = ChangeMetaData.PRIORITY_DEFAULT, description =
         "The 'renameType' tag allows you to rename the type ('from' attribute) of relationships to another type value ('to' attribute).\n" +
                 "By default, all matching relationships will have their matching type renamed.\n" +
-                "Restricting the set of affected relationships is done with the Cypher 'fragment' attribute, which defines the pattern" +
+                "Restricting the set of affected relationships is done with the Cypher 'fragment' attribute, which defines the pattern " +
                 "to match relationships against.\n" +
                 "'renameType' also defines the 'outputVariable' attribute. This attribute denotes the variable used in the pattern for\n" +
                 "the relationships to merge. If the fragment is '(:Movie)<-[d:DIRECTED_BY]-(:Director {name: 'John Woo'})-[a:ACTED_IN]->(:Movie)', " +
@@ -72,43 +64,45 @@ public class RenameTypeChange extends BatchableChange {
     }
 
     @Override
-    public SqlStatement[] generateStatements(Database database) {
-        Logger log = Scope.getCurrentScope().getLog(getClass());
-        boolean supportsCallInTransactions = ((Neo4jDatabase) database).supportsCallInTransactions();
-        if (supportsCallInTransactions && enableBatchImport) {
-            log.info("Running type rename in CALL {} IN TRANSACTIONS");
-
+    protected SqlStatement[] generateBatchedStatements(Neo4jDatabase neo4j) {
+        if (supportsDynamicTypes(neo4j)) {
+            String cypher = String.format("%s CALL {WITH __rel__ MATCH (__start__) " +
+                                          "WHERE id(__start__) = id(startNode(__rel__)) " +
+                                          "MATCH (__end__) WHERE id(__end__) = id(endNode(__rel__)) " +
+                                          "CREATE (__start__)-[__newrel__:$($2)]->(__end__) " +
+                                          "SET __newrel__ = properties(__rel__) " +
+                                          "DELETE __rel__ } " +
+                                          "IN TRANSACTIONS%s", queryStart(neo4j), cypherBatchSpec());
+            return new SqlStatement[]{new RawParameterizedSqlStatement(cypher, from, to)};
         }
-        if (!supportsCallInTransactions) {
-            log.warning("This version of Neo4j does not support CALL {} IN TRANSACTIONS, the type rename is going to run in a single, possibly large and slow, transaction.\n" +
-                    "Note: upgrade the Neo4j server or set the runInTransaction attribute of the enclosing change set to true to make this warning disappear.");
-        } else {
-            log.info("Running type rename in single transaction (set enableBatchImport to true to switch to CALL {} IN TRANSACTIONS)");
-        }
-        String cypher = String.format("%s MATCH (__start__) WHERE id(__start__) = id(startNode(__rel__)) MATCH (__end__) WHERE id(__end__) = id(endNode(__rel__)) CREATE (__start__)-[__newrel__:`%s`]->(__end__) SET __newrel__ = properties(__rel__) DELETE __rel__", queryStart(), to);
-        return new SqlStatement[]{new RawParameterizedSqlStatement(cypher, from)};
-    }
 
-    @Override
-    protected SqlStatement[] generateBatchedStatements(Database database) {
         String cypher = String.format("%s CALL {WITH __rel__ MATCH (__start__) " +
                 "WHERE id(__start__) = id(startNode(__rel__)) " +
                 "MATCH (__end__) WHERE id(__end__) = id(endNode(__rel__)) " +
                 "CREATE (__start__)-[__newrel__:`%s`]->(__end__) " +
                 "SET __newrel__ = properties(__rel__) " +
                 "DELETE __rel__ } " +
-                "IN TRANSACTIONS%s", queryStart(), to, cypherBatchSpec());
+                "IN TRANSACTIONS%s", queryStart(neo4j), to, cypherBatchSpec());
         return new SqlStatement[]{new RawParameterizedSqlStatement(cypher, from)};
     }
 
     @Override
-    protected SqlStatement[] generateUnbatchedStatements(Database database) {
+    protected SqlStatement[] generateUnbatchedStatements(Neo4jDatabase neo4j) {
+        if (supportsDynamicTypes(neo4j)) {
+            String cypher = String.format("%s MATCH (__start__) " +
+                                          "WHERE id(__start__) = id(startNode(__rel__)) " +
+                                          "MATCH (__end__) WHERE id(__end__) = id(endNode(__rel__)) " +
+                                          "CREATE (__start__)-[__newrel__:$($2)]->(__end__) " +
+                                          "SET __newrel__ = properties(__rel__) " +
+                                          "DELETE __rel__", queryStart(neo4j));
+            return new SqlStatement[]{new RawParameterizedSqlStatement(cypher, from, to)};
+        }
         String cypher = String.format("%s MATCH (__start__) " +
                 "WHERE id(__start__) = id(startNode(__rel__)) " +
                 "MATCH (__end__) WHERE id(__end__) = id(endNode(__rel__)) " +
                 "CREATE (__start__)-[__newrel__:`%s`]->(__end__) " +
                 "SET __newrel__ = properties(__rel__) " +
-                "DELETE __rel__", queryStart(), to);
+                "DELETE __rel__", queryStart(neo4j), to);
         return new SqlStatement[]{new RawParameterizedSqlStatement(cypher, from)};
     }
 
@@ -143,10 +137,19 @@ public class RenameTypeChange extends BatchableChange {
     public void setOutputVariable(String outputVariable) {
         this.outputVariable = outputVariable;
     }
-    private String queryStart() {
+    private String queryStart(Neo4jDatabase neo4j) {
         if (fragment != null) {
             return String.format("MATCH %s WITH %s AS __rel__ WHERE type(__rel__) = $1", fragment, outputVariable);
         }
+        if (supportsDynamicTypes(neo4j)) {
+            return "MATCH ()-[__rel__:$($1)]->()";
+        }
         return String.format("MATCH ()-[__rel__:`%s`]->()", from);
+    }
+
+    private static boolean supportsDynamicTypes(Neo4jDatabase neo4j) {
+        // 5.24: dynamic labels/properties in SET and REMOVE
+        // 5.26: dynamic labels/types/properties in CREATE, MATCH and MERGE
+        return neo4j.getKernelVersion().compareTo(V5_26_0) >= 0;
     }
 }

--- a/src/main/java/liquibase/ext/neo4j/database/KernelVersion.java
+++ b/src/main/java/liquibase/ext/neo4j/database/KernelVersion.java
@@ -4,11 +4,13 @@ import java.util.Objects;
 
 public class KernelVersion implements Comparable<KernelVersion> {
 
-    public static final KernelVersion V3_5 = new KernelVersion(3, 5, 0);
-    public static final KernelVersion V4_0 = new KernelVersion(4, 0, 0);
-    public static final KernelVersion V4_3 = new KernelVersion(4, 3, 0);
-    public static final KernelVersion V4_4 = new KernelVersion(4, 4, 0);
-    public static final KernelVersion V5_0 = new KernelVersion(5, 0, 0);
+    public static final KernelVersion V3_5_0 = new KernelVersion(3, 5, 0);
+    public static final KernelVersion V4_0_0 = new KernelVersion(4, 0, 0);
+    public static final KernelVersion V4_3_0 = new KernelVersion(4, 3, 0);
+    public static final KernelVersion V4_4_0 = new KernelVersion(4, 4, 0);
+    public static final KernelVersion V5_0_0 = new KernelVersion(5, 0, 0);
+    public static final KernelVersion V5_24_0 = new KernelVersion(5, 24, 0);
+    public static final KernelVersion V5_26_0 = new KernelVersion(5, 26, 0);
 
     private final int major;
     private final int minor;

--- a/src/main/java/liquibase/ext/neo4j/database/KernelVersion.java
+++ b/src/main/java/liquibase/ext/neo4j/database/KernelVersion.java
@@ -1,0 +1,126 @@
+package liquibase.ext.neo4j.database;
+
+import java.util.Objects;
+
+public class KernelVersion implements Comparable<KernelVersion> {
+
+    public static final KernelVersion V3_5 = new KernelVersion(3, 5, 0);
+    public static final KernelVersion V4_0 = new KernelVersion(4, 0, 0);
+    public static final KernelVersion V4_3 = new KernelVersion(4, 3, 0);
+    public static final KernelVersion V4_4 = new KernelVersion(4, 4, 0);
+    public static final KernelVersion V5_0 = new KernelVersion(5, 0, 0);
+
+    private final int major;
+    private final int minor;
+    private final int patch;
+
+    public static KernelVersion parse(String version) {
+        int major = -1;
+        int minor = -1;
+        int patch = -1;
+        String buffer = "";
+        for (char c : version.toCharArray()) {
+            if (c != '.') {
+                buffer += c;
+                continue;
+            }
+            if (major == -1) {
+                major = Integer.parseInt(buffer, 10);
+            } else if (minor == -1) {
+                minor = parseMinor(buffer);
+            }
+            buffer = "";
+        }
+        if (!buffer.isEmpty()) {
+            if (major == -1) {
+                major = Integer.parseInt(buffer, 10);
+            } else if (minor == -1) {
+                minor = parseMinor(buffer);
+            } else {
+                patch = Integer.parseInt(buffer, 10);
+            }
+        }
+        if (major == -1) {
+            throw new IllegalArgumentException(String.format("Invalid Neo4j version: %s", version));
+        }
+        if (minor == -1) {
+            return new KernelVersion(major);
+        }
+        if (patch == -1) {
+            return new KernelVersion(major, minor);
+        }
+        return new KernelVersion(major, minor, patch);
+    }
+
+    public KernelVersion(int major) {
+        this(major, Integer.MAX_VALUE);
+    }
+
+    public KernelVersion(int major, int minor) {
+        this(major, minor, Integer.MAX_VALUE);
+    }
+
+    public KernelVersion(int major, int minor, int patch) {
+        this.major = major;
+        this.minor = minor;
+        this.patch = patch;
+    }
+
+    public int major() {
+        return major;
+    }
+
+    public int minor() {
+        return minor;
+    }
+
+    public int patch() {
+        return patch;
+    }
+
+    @Override
+    public int compareTo(KernelVersion other) {
+        if (major != other.major) {
+            return signum(major - other.major);
+        }
+        if (minor != other.minor) {
+            return signum(minor - other.minor);
+        }
+        return signum(patch - other.patch);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof KernelVersion)) return false;
+        KernelVersion that = (KernelVersion) o;
+        return major == that.major && minor == that.minor && patch == that.patch;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(major, minor, patch);
+    }
+
+    @Override
+    public String toString() {
+        return versionString();
+    }
+
+    public String versionString() {
+        if (minor == Integer.MAX_VALUE) {
+            return String.format("%d", major);
+        }
+        if (patch == Integer.MAX_VALUE) {
+            return String.format("%d.%d", major, minor);
+        }
+        return String.format("%d.%d.%d", major, minor, patch);
+    }
+
+    private static int signum(int result) {
+        return (int) Math.signum(result);
+    }
+
+    private static int parseMinor(String buffer) {
+        return Integer.parseInt(buffer.replace("-aura", ""), 10);
+    }
+}

--- a/src/main/java/liquibase/ext/neo4j/database/Neo4jDatabase.java
+++ b/src/main/java/liquibase/ext/neo4j/database/Neo4jDatabase.java
@@ -17,9 +17,9 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.stream;
-import static liquibase.ext.neo4j.database.KernelVersion.V3_5;
-import static liquibase.ext.neo4j.database.KernelVersion.V4_0;
-import static liquibase.ext.neo4j.database.KernelVersion.V5_0;
+import static liquibase.ext.neo4j.database.KernelVersion.V3_5_0;
+import static liquibase.ext.neo4j.database.KernelVersion.V4_0_0;
+import static liquibase.ext.neo4j.database.KernelVersion.V5_0_0;
 import static liquibase.ext.neo4j.database.jdbc.SupportedJdbcUrl.IS_SUPPORTED_JDBC_URL;
 import static liquibase.ext.neo4j.lockservice.Exceptions.convertToRuntimeException;
 import static liquibase.ext.neo4j.lockservice.Exceptions.messageContaining;
@@ -93,7 +93,7 @@ public class Neo4jDatabase extends AbstractJdbcDatabase {
 
     @Override
     public boolean supportsCatalogs() {
-        return kernelVersion.compareTo(V4_0) >= 0 && isEnterprise();
+        return kernelVersion.compareTo(V4_0_0) >= 0 && isEnterprise();
     }
 
     @Override
@@ -107,11 +107,11 @@ public class Neo4jDatabase extends AbstractJdbcDatabase {
     }
 
     public void createIndex(String name, String label, String property) throws DatabaseException {
-        if (kernelVersion.compareTo(V5_0) >= 0) {
+        if (kernelVersion.compareTo(V5_0_0) >= 0) {
             createIndexForNeo4j5(name, label, property);
-        } else if (kernelVersion.compareTo(V4_0) >= 0) {
+        } else if (kernelVersion.compareTo(V4_0_0) >= 0) {
             createIndexForNeo4j4(name, label, property);
-        } else  if (kernelVersion.compareTo(V3_5) >= 0) {
+        } else  if (kernelVersion.compareTo(V3_5_0) >= 0) {
             createIndexForNeo4j3(label, property);
         } else{
             throw new DatabaseException(String.format(
@@ -124,11 +124,11 @@ public class Neo4jDatabase extends AbstractJdbcDatabase {
     }
 
     public void createUniqueConstraint(String name, String label, String property) throws DatabaseException {
-        if (kernelVersion.compareTo(V5_0) >= 0) {
+        if (kernelVersion.compareTo(V5_0_0) >= 0) {
             createUniqueConstraintForNeo4j5(name, label, property);
-        } else if (kernelVersion.compareTo(V4_0) >= 0) {
+        } else if (kernelVersion.compareTo(V4_0_0) >= 0) {
             createUniqueConstraintForNeo4j4(name, label, property);
-        } else if (kernelVersion.compareTo(V3_5) >= 0) {
+        } else if (kernelVersion.compareTo(V3_5_0) >= 0) {
             createUniqueConstraintForNeo4j3(label, property);
         } else {
             throw new DatabaseException(String.format(
@@ -145,11 +145,11 @@ public class Neo4jDatabase extends AbstractJdbcDatabase {
             return;
         }
         String[] properties = Arrays.prepend(firstProperty, rest, String.class);
-        if (kernelVersion.compareTo(V5_0) >= 0) {
+        if (kernelVersion.compareTo(V5_0_0) >= 0) {
             createNodeKeyConstraintForNeo4j5(name, label, properties);
-        } else if (kernelVersion.compareTo(V4_0) >= 0) {
+        } else if (kernelVersion.compareTo(V4_0_0) >= 0) {
             createNodeKeyConstraintForNeo4j4(name, label, properties);
-        } else if (kernelVersion.compareTo(V3_5) >= 0) {
+        } else if (kernelVersion.compareTo(V3_5_0) >= 0) {
             createNodeKeyConstraintForNeo4j3(label, properties);
         } else{
             throw new DatabaseException(String.format(
@@ -162,11 +162,11 @@ public class Neo4jDatabase extends AbstractJdbcDatabase {
     }
 
     public void dropIndex(String name, String label, String property) throws DatabaseException {
-        if (kernelVersion.compareTo(V5_0) >= 0) {
+        if (kernelVersion.compareTo(V5_0_0) >= 0) {
             dropIndexForNeo4j5(name);
-        } else if (kernelVersion.compareTo(V4_0) >= 0) {
+        } else if (kernelVersion.compareTo(V4_0_0) >= 0) {
             dropIndexForNeo4j4(name);
-        } else if (kernelVersion.compareTo(V3_5) >= 0) {
+        } else if (kernelVersion.compareTo(V3_5_0) >= 0) {
             dropIndexForNeo4j3(label, property);
         } else {
             throw new DatabaseException(String.format(
@@ -179,11 +179,11 @@ public class Neo4jDatabase extends AbstractJdbcDatabase {
     }
 
     public void dropUniqueConstraint(String name, String label, String property) throws DatabaseException {
-        if (kernelVersion.compareTo(V5_0) >= 0) {
+        if (kernelVersion.compareTo(V5_0_0) >= 0) {
             dropConstraintForNeo4j5(name);
-        } else if (kernelVersion.compareTo(V4_0) >= 0) {
+        } else if (kernelVersion.compareTo(V4_0_0) >= 0) {
             dropConstraintForNeo4j4(name);
-        } else if (kernelVersion.compareTo(V3_5) >= 0) {
+        } else if (kernelVersion.compareTo(V3_5_0) >= 0) {
             dropUniqueConstraintForNeo4j3(label, property);
         } else {
             throw new DatabaseException(String.format(
@@ -200,11 +200,11 @@ public class Neo4jDatabase extends AbstractJdbcDatabase {
             return;
         }
         String[] properties = Arrays.prepend(firstProperty, rest, String.class);
-        if (kernelVersion.compareTo(V5_0) >= 0) {
+        if (kernelVersion.compareTo(V5_0_0) >= 0) {
             dropConstraintForNeo4j5(name);
-        } else if (kernelVersion.compareTo(V4_0) >= 0) {
+        } else if (kernelVersion.compareTo(V4_0_0) >= 0) {
             dropConstraintForNeo4j4(name);
-        } else if (kernelVersion.compareTo(V3_5) >= 0) {
+        } else if (kernelVersion.compareTo(V3_5_0) >= 0) {
             dropNodeKeyConstraintForNeo4j3(label, properties);
         } else {
             throw new DatabaseException(String.format(
@@ -224,8 +224,9 @@ public class Neo4jDatabase extends AbstractJdbcDatabase {
         return jdbcExecutor().queryForList(statement);
     }
 
+    // FIXME: inline and remove this
     public boolean supportsCallInTransactions() {
-        return kernelVersion.compareTo(KernelVersion.V4_4) >= 0;
+        return kernelVersion.compareTo(KernelVersion.V4_4_0) >= 0;
     }
 
     public KernelVersion getKernelVersion() {

--- a/src/main/java/liquibase/ext/neo4j/precondition/Neo4jVersionPrecondition.java
+++ b/src/main/java/liquibase/ext/neo4j/precondition/Neo4jVersionPrecondition.java
@@ -8,6 +8,7 @@ import liquibase.exception.PreconditionErrorException;
 import liquibase.exception.PreconditionFailedException;
 import liquibase.exception.ValidationErrors;
 import liquibase.exception.Warnings;
+import liquibase.ext.neo4j.database.KernelVersion;
 import liquibase.ext.neo4j.database.Neo4jDatabase;
 import liquibase.precondition.AbstractPrecondition;
 import liquibase.precondition.FailedPrecondition;
@@ -49,8 +50,8 @@ public class Neo4jVersionPrecondition extends AbstractPrecondition {
                     changeLog, this)
             );
         }
-        String neo4jVersion = ((Neo4jDatabase) database).getNeo4jVersion();
-        if (!versionMatches(matches, neo4jVersion)) {
+        KernelVersion neo4jVersion = ((Neo4jDatabase) database).getKernelVersion();
+        if (!versionMatches(matches, neo4jVersion.versionString())) {
             throw new PreconditionFailedException(new FailedPrecondition(
                     String.format("expected %s version but got %s", matches, neo4jVersion),
                     changeLog, this)

--- a/src/test/groovy/liquibase/ext/neo4j/CypherRunner.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/CypherRunner.groovy
@@ -1,6 +1,6 @@
 package liquibase.ext.neo4j
 
-import liquibase.ext.neo4j.database.KernelVersion
+
 import liquibase.statement.SqlStatement
 import liquibase.statement.core.RawParameterizedSqlStatement
 import liquibase.statement.core.RawSqlStatement
@@ -11,9 +11,9 @@ import java.util.stream.Collectors
 import java.util.stream.IntStream
 
 import static liquibase.ext.neo4j.DockerNeo4j.neo4jVersion
-import static liquibase.ext.neo4j.database.KernelVersion.V4_0
-import static liquibase.ext.neo4j.database.KernelVersion.V4_3
-import static liquibase.ext.neo4j.database.KernelVersion.V5_0
+import static liquibase.ext.neo4j.database.KernelVersion.V4_0_0
+import static liquibase.ext.neo4j.database.KernelVersion.V4_3_0
+import static liquibase.ext.neo4j.database.KernelVersion.V5_0_0
 
 class CypherRunner implements AutoCloseable {
 
@@ -26,8 +26,8 @@ class CypherRunner implements AutoCloseable {
     void createIndex(String name, String label, String property) {
         ignoring(exceptionMessageContaining("index already exists"), {
             def neo4jVersion = neo4jVersion()
-            def query = neo4jVersion >= V5_0 ?
-                    "CREATE INDEX $name IF NOT EXISTS FOR (n:$label) ON (n.$property)" : neo4jVersion >= V4_0 ?
+            def query = neo4jVersion >= V5_0_0 ?
+                    "CREATE INDEX $name IF NOT EXISTS FOR (n:$label) ON (n.$property)" : neo4jVersion >= V4_0_0 ?
                     "CREATE INDEX $name FOR (n:$label) ON (n.$property)" :
                     "CREATE INDEX ON :$label($property)"
             this.run(query)
@@ -37,8 +37,8 @@ class CypherRunner implements AutoCloseable {
     void createUniqueConstraint(String name, String label, String property) {
         ignoring(exceptionMessageContaining("constraint already exists"), {
             def neo4jVersion = neo4jVersion()
-            def query = neo4jVersion >= V5_0 ?
-                    "CREATE CONSTRAINT $name IF NOT EXISTS FOR (c:$label) REQUIRE c.$property IS UNIQUE" : neo4jVersion >= V4_0 ?
+            def query = neo4jVersion >= V5_0_0 ?
+                    "CREATE CONSTRAINT $name IF NOT EXISTS FOR (c:$label) REQUIRE c.$property IS UNIQUE" : neo4jVersion >= V4_0_0 ?
                     "CREATE CONSTRAINT $name ON (c:$label) ASSERT c.$property IS UNIQUE" :
                     "CREATE CONSTRAINT ON (c:$label) ASSERT c.$property IS UNIQUE"
             this.run(query)
@@ -48,8 +48,8 @@ class CypherRunner implements AutoCloseable {
     void createNodeKeyConstraint(String name, String label, String... properties) {
         ignoring(exceptionMessageContaining("constraint already exists"), {
             def neo4jVersion = neo4jVersion()
-            def query = neo4jVersion >= V5_0 ?
-                    "CREATE CONSTRAINT $name IF NOT EXISTS FOR (c:$label) REQUIRE (${properties.collect { "c.`$it`" }.join(", ")}) IS NODE KEY" : neo4jVersion >= V4_0 ?
+            def query = neo4jVersion >= V5_0_0 ?
+                    "CREATE CONSTRAINT $name IF NOT EXISTS FOR (c:$label) REQUIRE (${properties.collect { "c.`$it`" }.join(", ")}) IS NODE KEY" : neo4jVersion >= V4_0_0 ?
                     "CREATE CONSTRAINT $name ON (c:$label) ASSERT (${properties.collect { "c.`$it`" }.join(", ")}) IS NODE KEY" :
                     "CREATE CONSTRAINT ON (c:$label) ASSERT (${properties.collect { "c.`$it`" }.join(", ")}) IS NODE KEY"
             this.run(query)
@@ -57,7 +57,7 @@ class CypherRunner implements AutoCloseable {
     }
 
     List<String> listExistingConstraints() {
-        if (neo4jVersion() >= V4_3) {
+        if (neo4jVersion() >= V4_3_0) {
             def descriptions = (String[]) this.getSingleRow(
                     """
                     | SHOW CONSTRAINTS YIELD name, labelsOrTypes
@@ -71,7 +71,7 @@ class CypherRunner implements AutoCloseable {
     }
 
     List<String> listExistingIndices() {
-        if (neo4jVersion() >= V4_3) {
+        if (neo4jVersion() >= V4_3_0) {
             def descriptions = (String[]) this.getSingleRow(
                     """
                     | SHOW INDEXES YIELD name, labelsOrTypes
@@ -79,7 +79,7 @@ class CypherRunner implements AutoCloseable {
                     """.stripMargin())["descriptions"]
             return Arrays.asList(descriptions)
         }
-        if (neo4jVersion() >= V4_0) {
+        if (neo4jVersion() >= V4_0_0) {
             def descriptions = (String[]) this.getSingleRow(
                     """
                     | CALL db.indexes() YIELD name, labelsOrTypes
@@ -95,8 +95,8 @@ class CypherRunner implements AutoCloseable {
     void dropIndex(String name, String label, String property) {
         ignoring(exceptionMessageContaining("no such index"), {
             def neo4jVersion = neo4jVersion()
-            def query = neo4jVersion >= V5_0 ?
-                    "DROP INDEX $name IF EXISTS" : neo4jVersion >= V4_0 ?
+            def query = neo4jVersion >= V5_0_0 ?
+                    "DROP INDEX $name IF EXISTS" : neo4jVersion >= V4_0_0 ?
                     "DROP INDEX $name" :
                     "DROP INDEX ON :$label(`$property`)"
             this.run(query)
@@ -106,8 +106,8 @@ class CypherRunner implements AutoCloseable {
     void dropUniqueConstraint(String name, String label, String property) {
         ignoring(exceptionMessageContaining("no such constraint"), {
             def neo4jVersion = neo4jVersion()
-            def query = neo4jVersion >= V5_0 ?
-                    "DROP CONSTRAINT $name IF EXISTS" : neo4jVersion>= V4_0 ?
+            def query = neo4jVersion >= V5_0_0 ?
+                    "DROP CONSTRAINT $name IF EXISTS" : neo4jVersion>= V4_0_0 ?
                     "DROP CONSTRAINT $name" :
                     "DROP CONSTRAINT ON (c:$label) ASSERT c.$property IS UNIQUE"
             this.run(query)
@@ -117,8 +117,8 @@ class CypherRunner implements AutoCloseable {
     void dropNodeKeyConstraint(String name, String label, String... properties) {
         ignoring(exceptionMessageContaining("no such constraint"), {
             def neo4jVersion = neo4jVersion()
-            def query = neo4jVersion >= V5_0 ?
-                    "DROP CONSTRAINT $name IF EXISTS" : neo4jVersion>= V4_0 ?
+            def query = neo4jVersion >= V5_0_0 ?
+                    "DROP CONSTRAINT $name IF EXISTS" : neo4jVersion>= V4_0_0 ?
                     "DROP CONSTRAINT $name" :
                     "DROP CONSTRAINT ON (c:$label) ASSERT (${properties.collect { "c.`$it`" }.join(", ")}) IS NODE KEY"
             this.run(query)

--- a/src/test/groovy/liquibase/ext/neo4j/DockerNeo4j.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/DockerNeo4j.groovy
@@ -1,5 +1,6 @@
 package liquibase.ext.neo4j
 
+import liquibase.ext.neo4j.database.KernelVersion
 import org.testcontainers.containers.Neo4jContainer
 import org.testcontainers.utility.DockerImageName
 
@@ -19,24 +20,6 @@ class DockerNeo4j {
         return container.withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
     }
 
-    static boolean supportsCypherCallInTransactions() {
-        def version = neo4jVersion()
-        return version.startsWith("4.4") || Integer.parseInt(version.substring(0, 1)) >= 5
-    }
-
-    static boolean supportsShowConstraintsYieldSyntax() {
-        return supportsShowIndexesYieldSyntax()
-    }
-
-    static boolean supportsShowIndexesYieldSyntax() {
-        def version = neo4jVersion()
-        def major = Integer.parseInt(version.substring(0, 1))
-        def minor = version.contains(".") ? Integer.parseInt(version.substring(2, 3)) : Integer.MAX_VALUE
-        // SHOW INDEXES|CONSTRAINTS is supported since Neo4j 4.2
-        // SHOW INDEXES|CONSTRAINTS YIELD xxx RETURN xxx is supported since Neo4j 4.3
-        return major >= 5 || major == 4 && minor >= 3
-    }
-
     static String dockerTag() {
         return "${neo4jVersion()}${enterpriseEdition() ? "-enterprise" : ""}"
     }
@@ -45,7 +28,7 @@ class DockerNeo4j {
         return parseBoolean(System.getenv().getOrDefault("ENTERPRISE", "false"))
     }
 
-    static String neo4jVersion() {
-        return System.getenv().getOrDefault("NEO4J_VERSION", "4.4")
+    static KernelVersion neo4jVersion() {
+        return KernelVersion.parse(System.getenv().getOrDefault("NEO4J_VERSION", "4.4"))
     }
 }

--- a/src/test/groovy/liquibase/ext/neo4j/Neo4jContainerSpec.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/Neo4jContainerSpec.groovy
@@ -46,7 +46,7 @@ abstract class Neo4jContainerSpec extends Specification {
     def setupSpec() {
         neo4jContainer.start()
         queryRunner = new CypherRunner(
-                GraphDatabase.driver(neo4jContainer.getBoltUrl(), AuthTokens.basic("neo4j", PASSWORD)), dockerTag())
+                GraphDatabase.driver(neo4jContainer.getBoltUrl(), AuthTokens.basic("neo4j", PASSWORD)))
         database = DatabaseFactory.instance.openDatabase(
                 "jdbc:neo4j:${neo4jContainer.getBoltUrl()}",
                 "neo4j",

--- a/src/test/groovy/liquibase/ext/neo4j/change/RenameLabelChangeTest.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/change/RenameLabelChangeTest.groovy
@@ -2,6 +2,7 @@ package liquibase.ext.neo4j.change
 
 import liquibase.changelog.ChangeSet
 import liquibase.database.core.MySQLDatabase
+import liquibase.ext.neo4j.database.KernelVersion
 import liquibase.ext.neo4j.database.Neo4jDatabase
 import spock.lang.Specification
 
@@ -32,6 +33,7 @@ class RenameLabelChangeTest extends Specification {
         renameLabelChange.setChangeSet(changeSet)
         def database = Mock(Neo4jDatabase)
         database.supportsCallInTransactions() >> withCIT
+        database.getKernelVersion() >> Mock(KernelVersion)
 
         expect:
         renameLabelChange.validate(database).getErrorMessages() == [error]

--- a/src/test/groovy/liquibase/ext/neo4j/change/RenamePropertyChangeTest.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/change/RenamePropertyChangeTest.groovy
@@ -2,6 +2,7 @@ package liquibase.ext.neo4j.change
 
 import liquibase.changelog.ChangeSet
 import liquibase.database.core.MySQLDatabase
+import liquibase.ext.neo4j.database.KernelVersion
 import liquibase.ext.neo4j.database.Neo4jDatabase
 import spock.lang.Specification
 
@@ -30,6 +31,7 @@ class RenamePropertyChangeTest extends Specification {
         renamePropertyChange.setChangeSet(changeSet)
         def database = Mock(Neo4jDatabase)
         database.supportsCallInTransactions() >> withCIT
+        database.getKernelVersion() >> Mock(KernelVersion)
 
         expect:
         renamePropertyChange.validate(database).getErrorMessages() == [error]

--- a/src/test/groovy/liquibase/ext/neo4j/change/RenameTypeChangeTest.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/change/RenameTypeChangeTest.groovy
@@ -2,6 +2,7 @@ package liquibase.ext.neo4j.change
 
 import liquibase.changelog.ChangeSet
 import liquibase.database.core.MySQLDatabase
+import liquibase.ext.neo4j.database.KernelVersion
 import liquibase.ext.neo4j.database.Neo4jDatabase
 import spock.lang.Specification
 
@@ -32,6 +33,7 @@ class RenameTypeChangeTest extends Specification {
         renameLabelChange.setChangeSet(changeSet)
         def database = Mock(Neo4jDatabase)
         database.supportsCallInTransactions() >> withCIT
+        database.getKernelVersion() >> Mock(KernelVersion)
 
         expect:
         renameLabelChange.validate(database).getErrorMessages() == [error]

--- a/src/test/groovy/liquibase/ext/neo4j/database/KernelVersionTest.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/database/KernelVersionTest.groovy
@@ -1,0 +1,68 @@
+package liquibase.ext.neo4j.database
+
+import spock.lang.Specification
+
+import static liquibase.ext.neo4j.database.KernelVersionTest.Sign.NEGATIVE
+import static liquibase.ext.neo4j.database.KernelVersionTest.Sign.POSITIVE
+import static liquibase.ext.neo4j.database.KernelVersionTest.Sign.ZERO
+
+class KernelVersionTest extends Specification {
+
+
+    def "parses versions"() {
+        expect:
+        KernelVersion.parse(version) == result
+
+        where:
+        version     | result
+        "1.0.0"     | new KernelVersion(1, 0, 0)
+        "1.0"       | new KernelVersion(1, 0)
+        "5.26-aura" | new KernelVersion(5, 26)
+        "5"         | new KernelVersion(5)
+    }
+
+    def "compares versions"() {
+        expect:
+        Sign.from(version1 <=> version2) == sign
+
+        where:
+        version1         | version2         | sign
+        version(1, 0, 0) | version(1, 0, 0) | ZERO
+        version(1, 0, 1) | version(1, 0, 0) | POSITIVE
+        version(1)       | version(1, 0, 0) | POSITIVE
+        version(1, 0)    | version(1, 0, 0) | POSITIVE
+        version(1, 1, 0) | version(1, 0, 0) | POSITIVE
+        version(1, 1)    | version(1, 0, 0) | POSITIVE
+        version(2, 0, 0) | version(1, 0, 0) | POSITIVE
+        version(2, 0)    | version(1, 0, 0) | POSITIVE
+        version(1, 0, 0) | version(1, 0, 1) | NEGATIVE
+        version(1, 0, 0) | version(1)       | NEGATIVE
+        version(1, 0, 0) | version(1, 0)    | NEGATIVE
+        version(1, 0, 0) | version(1, 1, 0) | NEGATIVE
+        version(1, 0, 0) | version(1, 1)    | NEGATIVE
+        version(1, 0, 0) | version(2, 0, 0) | NEGATIVE
+        version(1, 0, 0) | version(2, 0)    | NEGATIVE
+    }
+
+    private static KernelVersion version(int major) {
+        new KernelVersion(major)
+    }
+
+    private static KernelVersion version(int major, int minor) {
+        new KernelVersion(major, minor)
+    }
+
+    private static KernelVersion version(int major, int minor, int patch) {
+        new KernelVersion(major, minor, patch)
+    }
+
+    enum Sign {
+        NEGATIVE, ZERO, POSITIVE
+
+        static Sign from(int result) {
+            if (result > 0) return POSITIVE
+            if (result < 0) return NEGATIVE
+            return ZERO
+        }
+    }
+}

--- a/src/test/groovy/liquibase/ext/neo4j/database/Neo4jDatabaseIT.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/database/Neo4jDatabaseIT.groovy
@@ -2,6 +2,7 @@ package liquibase.ext.neo4j.database
 
 import liquibase.database.DatabaseConnection
 import liquibase.database.DatabaseFactory
+import liquibase.ext.neo4j.DockerNeo4j
 import liquibase.ext.neo4j.Neo4jContainerSpec
 
 import static liquibase.ext.neo4j.DockerNeo4j.enterpriseEdition
@@ -27,10 +28,13 @@ class Neo4jDatabaseIT extends Neo4jContainerSpec {
         database.setConnection(connection)
 
         then:
-        database.getNeo4jVersion().startsWith(neo4jVersion())
+        def configuredVersion = neo4jVersion()
+        def actualVersion = database.getKernelVersion()
+        actualVersion.major() == configuredVersion.major() &&
+                (actualVersion.minor() == configuredVersion.minor() || configuredVersion.minor() == Integer.MAX_VALUE)
     }
 
-    def "supports catalog if Neo4j version is 4+"() {
+    def "supports catalog if Neo4j version is 4+ and edition is enterprise"() {
         given:
         def database = new Neo4jDatabase()
 
@@ -38,7 +42,7 @@ class Neo4jDatabaseIT extends Neo4jContainerSpec {
         database.setConnection(connection)
 
         then:
-        database.supportsCatalogs() == Integer.parseInt(neo4jVersion().substring(0, 1), 10) >= 4
+        database.supportsCatalogs() == (neo4jVersion() >= KernelVersion.V4_0 && enterpriseEdition())
     }
 
     def "detects server edition"() {

--- a/src/test/groovy/liquibase/ext/neo4j/database/Neo4jDatabaseIT.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/database/Neo4jDatabaseIT.groovy
@@ -2,7 +2,6 @@ package liquibase.ext.neo4j.database
 
 import liquibase.database.DatabaseConnection
 import liquibase.database.DatabaseFactory
-import liquibase.ext.neo4j.DockerNeo4j
 import liquibase.ext.neo4j.Neo4jContainerSpec
 
 import static liquibase.ext.neo4j.DockerNeo4j.enterpriseEdition
@@ -42,7 +41,7 @@ class Neo4jDatabaseIT extends Neo4jContainerSpec {
         database.setConnection(connection)
 
         then:
-        database.supportsCatalogs() == (neo4jVersion() >= KernelVersion.V4_0 && enterpriseEdition())
+        database.supportsCatalogs() == (neo4jVersion() >= KernelVersion.V4_0_0 && enterpriseEdition())
     }
 
     def "detects server edition"() {

--- a/src/test/groovy/liquibase/ext/neo4j/database/jdbc/Neo4jStatementIT.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/database/jdbc/Neo4jStatementIT.groovy
@@ -1,10 +1,10 @@
 package liquibase.ext.neo4j.database.jdbc
 
-
 import liquibase.ext.neo4j.Neo4jContainerSpec
 import spock.lang.Requires
 
-import static liquibase.ext.neo4j.DockerNeo4j.supportsCypherCallInTransactions
+import static liquibase.ext.neo4j.DockerNeo4j.neo4jVersion
+import static liquibase.ext.neo4j.database.KernelVersion.V4_4
 
 class Neo4jStatementIT extends Neo4jContainerSpec {
 
@@ -51,7 +51,7 @@ class Neo4jStatementIT extends Neo4jContainerSpec {
         connection.close()
     }
 
-    @Requires({ supportsCypherCallInTransactions() })
+    @Requires({ neo4jVersion() >= V4_4 })
     def "executes auto-commit statements"() {
         given:
         def connection = new Neo4jDriver().connect(jdbcUrl(), authenticationProperties())
@@ -116,7 +116,7 @@ class Neo4jStatementIT extends Neo4jContainerSpec {
         connection.close()
     }
 
-    @Requires({ supportsCypherCallInTransactions() })
+    @Requires({ neo4jVersion() >= V4_4 })
     def "executes autocommit parameterized statements"() {
         given:
         def connection = new Neo4jDriver().connect(jdbcUrl(), authenticationProperties())

--- a/src/test/groovy/liquibase/ext/neo4j/database/jdbc/Neo4jStatementIT.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/database/jdbc/Neo4jStatementIT.groovy
@@ -4,7 +4,7 @@ import liquibase.ext.neo4j.Neo4jContainerSpec
 import spock.lang.Requires
 
 import static liquibase.ext.neo4j.DockerNeo4j.neo4jVersion
-import static liquibase.ext.neo4j.database.KernelVersion.V4_4
+import static liquibase.ext.neo4j.database.KernelVersion.V4_4_0
 
 class Neo4jStatementIT extends Neo4jContainerSpec {
 
@@ -51,7 +51,7 @@ class Neo4jStatementIT extends Neo4jContainerSpec {
         connection.close()
     }
 
-    @Requires({ neo4jVersion() >= V4_4 })
+    @Requires({ neo4jVersion() >= V4_4_0 })
     def "executes auto-commit statements"() {
         given:
         def connection = new Neo4jDriver().connect(jdbcUrl(), authenticationProperties())
@@ -116,7 +116,7 @@ class Neo4jStatementIT extends Neo4jContainerSpec {
         connection.close()
     }
 
-    @Requires({ neo4jVersion() >= V4_4 })
+    @Requires({ neo4jVersion() >= V4_4_0 })
     def "executes autocommit parameterized statements"() {
         given:
         def connection = new Neo4jDriver().connect(jdbcUrl(), authenticationProperties())

--- a/src/test/groovy/liquibase/ext/neo4j/e2e/AutocommitIT.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/e2e/AutocommitIT.groovy
@@ -8,11 +8,11 @@ import liquibase.ext.neo4j.Neo4jContainerSpec
 import spock.lang.Requires
 
 import static liquibase.ext.neo4j.DockerNeo4j.neo4jVersion
-import static liquibase.ext.neo4j.database.KernelVersion.V4_4
+import static liquibase.ext.neo4j.database.KernelVersion.V4_4_0
 
 class AutocommitIT extends Neo4jContainerSpec {
 
-    @Requires({ neo4jVersion() >= V4_4 })
+    @Requires({ neo4jVersion() >= V4_4_0 })
     def "runs autocommit transaction"() {
         given:
         def command = new CommandScope(UpdateCommandStep.COMMAND_NAME)
@@ -36,7 +36,7 @@ class AutocommitIT extends Neo4jContainerSpec {
         format << ["cypher", "json", "xml", "yaml"]
     }
 
-    @Requires({ (neo4jVersion() >= V4_4) })
+    @Requires({ (neo4jVersion() >= V4_4_0) })
     def "runs autocommit transactions mixed with default explicit transactions"() {
         given:
         def command = new CommandScope(UpdateCommandStep.COMMAND_NAME)

--- a/src/test/groovy/liquibase/ext/neo4j/e2e/AutocommitIT.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/e2e/AutocommitIT.groovy
@@ -7,11 +7,12 @@ import liquibase.command.core.helpers.DbUrlConnectionCommandStep
 import liquibase.ext.neo4j.Neo4jContainerSpec
 import spock.lang.Requires
 
-import static liquibase.ext.neo4j.DockerNeo4j.supportsCypherCallInTransactions
+import static liquibase.ext.neo4j.DockerNeo4j.neo4jVersion
+import static liquibase.ext.neo4j.database.KernelVersion.V4_4
 
 class AutocommitIT extends Neo4jContainerSpec {
 
-    @Requires({ supportsCypherCallInTransactions() })
+    @Requires({ neo4jVersion() >= V4_4 })
     def "runs autocommit transaction"() {
         given:
         def command = new CommandScope(UpdateCommandStep.COMMAND_NAME)
@@ -35,7 +36,7 @@ class AutocommitIT extends Neo4jContainerSpec {
         format << ["cypher", "json", "xml", "yaml"]
     }
 
-    @Requires({ supportsCypherCallInTransactions() })
+    @Requires({ (neo4jVersion() >= V4_4) })
     def "runs autocommit transactions mixed with default explicit transactions"() {
         given:
         def command = new CommandScope(UpdateCommandStep.COMMAND_NAME)

--- a/src/test/groovy/liquibase/ext/neo4j/e2e/PreconditionsIT.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/e2e/PreconditionsIT.groovy
@@ -4,7 +4,6 @@ import liquibase.command.CommandScope
 import liquibase.command.core.UpdateCommandStep
 import liquibase.command.core.helpers.DatabaseChangelogCommandStep
 import liquibase.command.core.helpers.DbUrlConnectionCommandStep
-import liquibase.ext.neo4j.DockerNeo4j
 import liquibase.ext.neo4j.Neo4jContainerSpec
 import liquibase.ext.neo4j.database.KernelVersion
 
@@ -51,7 +50,7 @@ class PreconditionsIT extends Neo4jContainerSpec {
 
 
         def version = neo4jVersion()
-        row["isNeo4j44"] == (version >= KernelVersion.V4_4 && version.major() == 4 && version.minor() == 4)
+        row["isNeo4j44"] == (version >= KernelVersion.V4_4_0 && version.major() == 4 && version.minor() == 4)
 
         where:
         format << ["json", "xml", "yaml"]

--- a/src/test/groovy/liquibase/ext/neo4j/e2e/PreconditionsIT.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/e2e/PreconditionsIT.groovy
@@ -4,7 +4,9 @@ import liquibase.command.CommandScope
 import liquibase.command.core.UpdateCommandStep
 import liquibase.command.core.helpers.DatabaseChangelogCommandStep
 import liquibase.command.core.helpers.DbUrlConnectionCommandStep
+import liquibase.ext.neo4j.DockerNeo4j
 import liquibase.ext.neo4j.Neo4jContainerSpec
+import liquibase.ext.neo4j.database.KernelVersion
 
 import static liquibase.ext.neo4j.DockerNeo4j.enterpriseEdition
 import static liquibase.ext.neo4j.DockerNeo4j.neo4jVersion
@@ -47,7 +49,9 @@ class PreconditionsIT extends Neo4jContainerSpec {
             MATCH (n:Neo4j) RETURN n.neo4j44 AS isNeo4j44
         """)
 
-        row["isNeo4j44"] == (neo4jVersion() == "4.4")
+
+        def version = neo4jVersion()
+        row["isNeo4j44"] == (version >= KernelVersion.V4_4 && version.major() == 4 && version.minor() == 4)
 
         where:
         format << ["json", "xml", "yaml"]


### PR DESCRIPTION
This simplifies the generated queries by using the dynamic label,
property and type feature introduced in 5.24 and improved in 5.26.