### PR TITLE
Expose error policy and concurrency settings of batchable changes

### DIFF
--- a/docs/includes/_batching.md
+++ b/docs/includes/_batching.md
@@ -13,3 +13,12 @@ This results in the change being executed in batches.
 
 The `batchSize` attribute controls how many transactions run.
 If the attribute is not set, the batch size is defined on the Neo4j server side.
+
+The [error policy of inner transactions](https://neo4j.com/docs/cypher-manual/current/subqueries/subqueries-in-transactions/#error-behavior),
+introduced in Neo4j 5.7, is configurable with the `batchErrorPolicy` attribute, and accepts the following values:
+ - `CONTINUE`
+ - `BREAK`
+ - `FAIL`
+
+Inner transactions can also be configured to [run in parallel](https://neo4j.com/docs/cypher-manual/current/subqueries/subqueries-in-transactions/#error-behavior) since Neo4j 5.21.
+The boolean `concurrent` attribute controls that behavior. Concurrency is disabled by default.

--- a/src/main/java/liquibase/ext/neo4j/change/BatchErrorPolicy.java
+++ b/src/main/java/liquibase/ext/neo4j/change/BatchErrorPolicy.java
@@ -1,0 +1,5 @@
+package liquibase.ext.neo4j.change;
+
+public enum BatchErrorPolicy {
+    CONTINUE, BREAK, FAIL
+}

--- a/src/main/java/liquibase/ext/neo4j/change/InvertDirectionChange.java
+++ b/src/main/java/liquibase/ext/neo4j/change/InvertDirectionChange.java
@@ -66,7 +66,7 @@ public class InvertDirectionChange extends BatchableChange {
                 "   CREATE (__start__)<-[__newrel__:`%s`]-(__end__) " +
                 "   SET __newrel__ = properties(__rel__) " +
                 "   DELETE __rel__ " +
-                "} IN TRANSACTIONS%s", queryStart(), type, cypherBatchSpec());
+                "}%s", queryStart(), type, cypherBatchSpec());
         return new SqlStatement[]{new RawParameterizedSqlStatement(cypher, type)};
     }
 

--- a/src/main/java/liquibase/ext/neo4j/change/RenameLabelChange.java
+++ b/src/main/java/liquibase/ext/neo4j/change/RenameLabelChange.java
@@ -67,11 +67,11 @@ public class RenameLabelChange extends BatchableChange {
     @Override
     protected SqlStatement[] generateBatchedStatements(Neo4jDatabase neo4j) {
         if (supportsDynamicLabels(neo4j)) {
-            String cypher = String.format("%s CALL {WITH __node__ SET __node__:$($1) REMOVE __node__:$($2)} IN TRANSACTIONS%s",
+            String cypher = String.format("%s CALL {WITH __node__ SET __node__:$($1) REMOVE __node__:$($2)}%s",
                     queryStart(neo4j), cypherBatchSpec());
             return new SqlStatement[]{new RawParameterizedSqlStatement(cypher, to, from)};
         }
-        String cypher = String.format("%s CALL {WITH __node__ SET __node__:`%s` REMOVE __node__:`%s`} IN TRANSACTIONS%s",
+        String cypher = String.format("%s CALL {WITH __node__ SET __node__:`%s` REMOVE __node__:`%s`}%s",
                 queryStart(neo4j), to, from, cypherBatchSpec());
         return new SqlStatement[]{new RawSqlStatement(cypher)};
     }

--- a/src/main/java/liquibase/ext/neo4j/change/RenamePropertyChange.java
+++ b/src/main/java/liquibase/ext/neo4j/change/RenamePropertyChange.java
@@ -63,12 +63,12 @@ public class RenamePropertyChange extends BatchableChange {
     protected SqlStatement[] generateBatchedStatements(Neo4jDatabase database) {
         String batchSpec = cypherBatchSpec();
         if (supportsDynamicProperties(database)) {
-            String nodeRename = String.format("MATCH (n) WHERE n[$1] IS NOT NULL CALL { WITH n SET n[$2] = n[$1] REMOVE n[$1] } IN TRANSACTIONS%s", batchSpec);
-            String relRename = String.format("MATCH ()-[r]->() WHERE r[$1] IS NOT NULL CALL { WITH r SET r[$2] = r[$1] REMOVE r[$1] } IN TRANSACTIONS%s", batchSpec);
+            String nodeRename = String.format("MATCH (n) WHERE n[$1] IS NOT NULL CALL { WITH n SET n[$2] = n[$1] REMOVE n[$1] }%s", batchSpec);
+            String relRename = String.format("MATCH ()-[r]->() WHERE r[$1] IS NOT NULL CALL { WITH r SET r[$2] = r[$1] REMOVE r[$1] }%s", batchSpec);
             return filterStatements(nodeRename, relRename);
         }
-        String nodeRename = String.format("MATCH (n) WHERE n[$1] IS NOT NULL CALL { WITH n SET n.`%2$s` = n[$1] REMOVE n.`%1$s` } IN TRANSACTIONS%3$s", from, to, batchSpec);
-        String relRename = String.format("MATCH ()-[r]->() WHERE r[$1] IS NOT NULL CALL { WITH r SET r.`%2$s` = r[$1] REMOVE r.`%1$s` } IN TRANSACTIONS%3$s", from, to, batchSpec);
+        String nodeRename = String.format("MATCH (n) WHERE n[$1] IS NOT NULL CALL { WITH n SET n.`%2$s` = n[$1] REMOVE n.`%1$s` }%3$s", from, to, batchSpec);
+        String relRename = String.format("MATCH ()-[r]->() WHERE r[$1] IS NOT NULL CALL { WITH r SET r.`%2$s` = r[$1] REMOVE r.`%1$s` }%3$s", from, to, batchSpec);
         return filterStatements(nodeRename, relRename);
     }
 

--- a/src/main/java/liquibase/ext/neo4j/change/RenameTypeChange.java
+++ b/src/main/java/liquibase/ext/neo4j/change/RenameTypeChange.java
@@ -72,7 +72,7 @@ public class RenameTypeChange extends BatchableChange {
                                           "CREATE (__start__)-[__newrel__:$($2)]->(__end__) " +
                                           "SET __newrel__ = properties(__rel__) " +
                                           "DELETE __rel__ } " +
-                                          "IN TRANSACTIONS%s", queryStart(neo4j), cypherBatchSpec());
+                                          "%s", queryStart(neo4j), cypherBatchSpec());
             return new SqlStatement[]{new RawParameterizedSqlStatement(cypher, from, to)};
         }
 
@@ -82,7 +82,7 @@ public class RenameTypeChange extends BatchableChange {
                 "CREATE (__start__)-[__newrel__:`%s`]->(__end__) " +
                 "SET __newrel__ = properties(__rel__) " +
                 "DELETE __rel__ } " +
-                "IN TRANSACTIONS%s", queryStart(neo4j), to, cypherBatchSpec());
+                "%s", queryStart(neo4j), to, cypherBatchSpec());
         return new SqlStatement[]{new RawParameterizedSqlStatement(cypher, from)};
     }
 

--- a/src/main/java/liquibase/ext/neo4j/database/KernelVersion.java
+++ b/src/main/java/liquibase/ext/neo4j/database/KernelVersion.java
@@ -9,7 +9,9 @@ public class KernelVersion implements Comparable<KernelVersion> {
     public static final KernelVersion V4_3_0 = new KernelVersion(4, 3, 0);
     public static final KernelVersion V4_4_0 = new KernelVersion(4, 4, 0);
     public static final KernelVersion V5_0_0 = new KernelVersion(5, 0, 0);
+    public static final KernelVersion V5_7_0 = new KernelVersion(5, 7, 0);
     public static final KernelVersion V5_24_0 = new KernelVersion(5, 24, 0);
+    public static final KernelVersion V5_21_0 = new KernelVersion(5, 21, 0);
     public static final KernelVersion V5_26_0 = new KernelVersion(5, 26, 0);
 
     private final int major;

--- a/src/main/java/liquibase/ext/neo4j/database/Neo4jDatabase.java
+++ b/src/main/java/liquibase/ext/neo4j/database/Neo4jDatabase.java
@@ -224,11 +224,6 @@ public class Neo4jDatabase extends AbstractJdbcDatabase {
         return jdbcExecutor().queryForList(statement);
     }
 
-    // FIXME: inline and remove this
-    public boolean supportsCallInTransactions() {
-        return kernelVersion.compareTo(KernelVersion.V4_4_0) >= 0;
-    }
-
     public KernelVersion getKernelVersion() {
         return kernelVersion;
     }

--- a/src/main/resources/www.liquibase.org/xml/ns/neo4j/liquibase-neo4j-latest.xsd
+++ b/src/main/resources/www.liquibase.org/xml/ns/neo4j/liquibase-neo4j-latest.xsd
@@ -95,6 +95,16 @@
         <xsd:attribute type="xsd:string" name="outputVariable" />
         <xsd:attribute type="xsd:boolean" name="enableBatchImport" />
         <xsd:attribute type="xsd:int" name="batchSize" />
+        <xsd:attribute type="xsd:boolean" name="concurrent" />
+        <xsd:attribute type="xsd:string" name="batchErrorPolicy">
+            <xsd:simpleType>
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="CONTINUE"/>
+                    <xsd:enumeration value="BREAK"/>
+                    <xsd:enumeration value="FAIL"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+        </xsd:attribute>
     </xsd:complexType>
 
     <xsd:element name="renameType" type="renameTypeType" />
@@ -105,6 +115,16 @@
         <xsd:attribute type="xsd:string" name="outputVariable" />
         <xsd:attribute type="xsd:boolean" name="enableBatchImport" />
         <xsd:attribute type="xsd:int" name="batchSize" />
+        <xsd:attribute type="xsd:boolean" name="concurrent" />
+        <xsd:attribute type="xsd:string" name="batchErrorPolicy">
+            <xsd:simpleType>
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="CONTINUE"/>
+                    <xsd:enumeration value="BREAK"/>
+                    <xsd:enumeration value="FAIL"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+        </xsd:attribute>
     </xsd:complexType>
 
     <xsd:element name="invertDirection" type="invertDirectionType" />
@@ -114,6 +134,16 @@
         <xsd:attribute type="xsd:string" name="outputVariable" />
         <xsd:attribute type="xsd:boolean" name="enableBatchImport" />
         <xsd:attribute type="xsd:int" name="batchSize" />
+        <xsd:attribute type="xsd:boolean" name="concurrent" />
+        <xsd:attribute type="xsd:string" name="batchErrorPolicy">
+            <xsd:simpleType>
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="CONTINUE"/>
+                    <xsd:enumeration value="BREAK"/>
+                    <xsd:enumeration value="FAIL"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+        </xsd:attribute>
     </xsd:complexType>
 
     <xsd:element name="renameProperty" type="renamePropertyType" />
@@ -123,5 +153,15 @@
         <xsd:attribute type="xsd:string" name="entityType" />
         <xsd:attribute type="xsd:boolean" name="enableBatchImport" />
         <xsd:attribute type="xsd:int" name="batchSize" />
+        <xsd:attribute type="xsd:boolean" name="concurrent" />
+        <xsd:attribute type="xsd:string" name="batchErrorPolicy">
+            <xsd:simpleType>
+                <xsd:restriction base="xsd:string">
+                    <xsd:enumeration value="CONTINUE"/>
+                    <xsd:enumeration value="BREAK"/>
+                    <xsd:enumeration value="FAIL"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+        </xsd:attribute>
     </xsd:complexType>
 </xsd:schema>

--- a/src/test/groovy/liquibase/ext/neo4j/change/InvertDirectionChangeTest.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/change/InvertDirectionChangeTest.groovy
@@ -2,6 +2,7 @@ package liquibase.ext.neo4j.change
 
 import liquibase.changelog.ChangeSet
 import liquibase.database.core.MySQLDatabase
+import liquibase.ext.neo4j.database.KernelVersion
 import liquibase.ext.neo4j.database.Neo4jDatabase
 import spock.lang.Specification
 
@@ -30,7 +31,8 @@ class InvertDirectionChangeTest extends Specification {
         changeSet.runInTransaction >> runInTx
         renameLabelChange.setChangeSet(changeSet)
         def database = Mock(Neo4jDatabase)
-        database.supportsCallInTransactions() >> withCIT
+        def version = (withCIT) ? KernelVersion.V4_4_0 : KernelVersion.V4_3_0
+        database.getKernelVersion() >> version
 
         expect:
         renameLabelChange.validate(database).getErrorMessages() == [error]

--- a/src/test/groovy/liquibase/ext/neo4j/e2e/InvertDirectionIT.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/e2e/InvertDirectionIT.groovy
@@ -6,6 +6,10 @@ import liquibase.command.core.helpers.DatabaseChangelogCommandStep
 import liquibase.command.core.helpers.DbUrlConnectionCommandStep
 import liquibase.ext.neo4j.Neo4jContainerSpec
 
+import static liquibase.ext.neo4j.DockerNeo4j.neo4jVersion
+import static liquibase.ext.neo4j.database.KernelVersion.V5_21_0
+import static org.junit.jupiter.api.Assumptions.assumeTrue
+
 class InvertDirectionIT extends Neo4jContainerSpec {
 
     def "runs migrations inverting direction"() {
@@ -48,11 +52,14 @@ class InvertDirectionIT extends Neo4jContainerSpec {
 
     def "runs batched migrations inverting direction"() {
         given:
+        if (concurrent) {
+            assumeTrue(neo4jVersion() >= V5_21_0)
+        }
         def command = new CommandScope(UpdateCommandStep.COMMAND_NAME)
                 .addArgumentValue(DbUrlConnectionCommandStep.URL_ARG, "jdbc:neo4j:${neo4jContainer.getBoltUrl()}".toString())
                 .addArgumentValue(DbUrlConnectionCommandStep.USERNAME_ARG, "neo4j")
                 .addArgumentValue(DbUrlConnectionCommandStep.PASSWORD_ARG, PASSWORD)
-                .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, "/e2e/invert-direction/changeLog-simple-batched.${format}".toString())
+                .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, "/e2e/invert-direction/changeLog-simple-batched${if (concurrent) "-concurrent" else ""}.${format}".toString())
                 .setOutput(System.out)
         command.execute()
 
@@ -81,7 +88,7 @@ class InvertDirectionIT extends Neo4jContainerSpec {
         ]
 
         where:
-        format << ["json", "xml", "yaml"]
+        [format, concurrent] << [["json", "xml", "yaml"], [false, true]].combinations()
     }
 
     def "runs migrations inverting direction of matching relationships"() {
@@ -123,11 +130,14 @@ class InvertDirectionIT extends Neo4jContainerSpec {
 
     def "runs batched migrations inverting direction of matching relationships"() {
         given:
+        if (concurrent) {
+            assumeTrue(neo4jVersion() >= V5_21_0)
+        }
         def command = new CommandScope(UpdateCommandStep.COMMAND_NAME)
                 .addArgumentValue(DbUrlConnectionCommandStep.URL_ARG, "jdbc:neo4j:${neo4jContainer.getBoltUrl()}".toString())
                 .addArgumentValue(DbUrlConnectionCommandStep.USERNAME_ARG, "neo4j")
                 .addArgumentValue(DbUrlConnectionCommandStep.PASSWORD_ARG, PASSWORD)
-                .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, "/e2e/invert-direction/changeLog-pattern-batched.${format}".toString())
+                .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, "/e2e/invert-direction/changeLog-pattern-batched${if (concurrent) "-concurrent" else ""}.${format}".toString())
                 .setOutput(System.out)
         command.execute()
 
@@ -155,6 +165,6 @@ class InvertDirectionIT extends Neo4jContainerSpec {
         ]
 
         where:
-        format << ["json", "xml", "yaml"]
+        [format, concurrent] << [["json", "xml", "yaml"], [false, true]].combinations()
     }
 }

--- a/src/test/groovy/liquibase/ext/neo4j/e2e/RenameLabelIT.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/e2e/RenameLabelIT.groovy
@@ -6,6 +6,10 @@ import liquibase.command.core.helpers.DatabaseChangelogCommandStep
 import liquibase.command.core.helpers.DbUrlConnectionCommandStep
 import liquibase.ext.neo4j.Neo4jContainerSpec
 
+import static liquibase.ext.neo4j.DockerNeo4j.neo4jVersion
+import static liquibase.ext.neo4j.database.KernelVersion.V5_21_0
+import static org.junit.jupiter.api.Assumptions.assumeTrue
+
 class RenameLabelIT extends Neo4jContainerSpec {
 
     def "runs migrations renaming labels"() {
@@ -52,11 +56,14 @@ class RenameLabelIT extends Neo4jContainerSpec {
 
     def "runs batched migrations renaming labels"() {
         given:
+        if (concurrent) {
+            assumeTrue(neo4jVersion() >= V5_21_0)
+        }
         def command = new CommandScope(UpdateCommandStep.COMMAND_NAME)
                 .addArgumentValue(DbUrlConnectionCommandStep.URL_ARG, "jdbc:neo4j:${neo4jContainer.getBoltUrl()}".toString())
                 .addArgumentValue(DbUrlConnectionCommandStep.USERNAME_ARG, "neo4j")
                 .addArgumentValue(DbUrlConnectionCommandStep.PASSWORD_ARG, PASSWORD)
-                .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, "/e2e/rename-label/changeLog-simple-batched.${format}".toString())
+                .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, "/e2e/rename-label/changeLog-simple-batched${if (concurrent) "-concurrent" else ""}.$format".toString())
                 .setOutput(System.out)
         command.execute()
 
@@ -89,7 +96,7 @@ class RenameLabelIT extends Neo4jContainerSpec {
         ]
 
         where:
-        format << ["json", "xml", "yaml"]
+        [format, concurrent] << [["json", "xml", "yaml"], [false, true]].combinations()
     }
 
     def "runs migrations renaming labels of matching nodes"() {
@@ -136,11 +143,14 @@ class RenameLabelIT extends Neo4jContainerSpec {
 
     def "runs batched migrations renaming labels of matching nodes"() {
         given:
+        if (concurrent) {
+            assumeTrue(neo4jVersion() >= V5_21_0)
+        }
         def command = new CommandScope(UpdateCommandStep.COMMAND_NAME)
                 .addArgumentValue(DbUrlConnectionCommandStep.URL_ARG, "jdbc:neo4j:${neo4jContainer.getBoltUrl()}".toString())
                 .addArgumentValue(DbUrlConnectionCommandStep.USERNAME_ARG, "neo4j")
                 .addArgumentValue(DbUrlConnectionCommandStep.PASSWORD_ARG, PASSWORD)
-                .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, "/e2e/rename-label/changeLog-pattern-batched.${format}".toString())
+                .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, "/e2e/rename-label/changeLog-pattern-batched${if (concurrent) "-concurrent" else ""}.${format}".toString())
                 .setOutput(System.out)
         command.execute()
 
@@ -173,6 +183,6 @@ class RenameLabelIT extends Neo4jContainerSpec {
         ]
 
         where:
-        format << ["json", "xml", "yaml"]
+        [format, concurrent] << [["json", "xml", "yaml"], [false, true]].combinations()
     }
 }

--- a/src/test/groovy/liquibase/ext/neo4j/e2e/RenamePropertyIT.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/e2e/RenamePropertyIT.groovy
@@ -6,6 +6,10 @@ import liquibase.command.core.helpers.DatabaseChangelogCommandStep
 import liquibase.command.core.helpers.DbUrlConnectionCommandStep
 import liquibase.ext.neo4j.Neo4jContainerSpec
 
+import static liquibase.ext.neo4j.DockerNeo4j.neo4jVersion
+import static liquibase.ext.neo4j.database.KernelVersion.V5_21_0
+import static org.junit.jupiter.api.Assumptions.assumeTrue
+
 class RenamePropertyIT extends Neo4jContainerSpec {
 
     def "runs migrations renaming properties of all entities"() {
@@ -127,11 +131,14 @@ class RenamePropertyIT extends Neo4jContainerSpec {
 
     def "runs batched migrations renaming properties of all entities"() {
         given:
+        if (concurrent) {
+            assumeTrue(neo4jVersion() >= V5_21_0)
+        }
         def command = new CommandScope(UpdateCommandStep.COMMAND_NAME)
                 .addArgumentValue(DbUrlConnectionCommandStep.URL_ARG, "jdbc:neo4j:${neo4jContainer.getBoltUrl()}".toString())
                 .addArgumentValue(DbUrlConnectionCommandStep.USERNAME_ARG, "neo4j")
                 .addArgumentValue(DbUrlConnectionCommandStep.PASSWORD_ARG, PASSWORD)
-                .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, "/e2e/rename-property/changeLog-all-batched.${format}".toString())
+                .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, "/e2e/rename-property/changeLog-all-batched${if (concurrent) "-concurrent" else ""}.${format}".toString())
                 .setOutput(System.out)
         command.execute()
 
@@ -161,16 +168,19 @@ class RenamePropertyIT extends Neo4jContainerSpec {
         ]
 
         where:
-        format << ["json", "xml", "yaml"]
+        [format, concurrent] << [["json", "xml", "yaml"], [false, true]].combinations()
     }
 
     def "runs batched migrations renaming properties of nodes only"() {
         given:
+        if (concurrent) {
+            assumeTrue(neo4jVersion() >= V5_21_0)
+        }
         def command = new CommandScope(UpdateCommandStep.COMMAND_NAME)
                 .addArgumentValue(DbUrlConnectionCommandStep.URL_ARG, "jdbc:neo4j:${neo4jContainer.getBoltUrl()}".toString())
                 .addArgumentValue(DbUrlConnectionCommandStep.USERNAME_ARG, "neo4j")
                 .addArgumentValue(DbUrlConnectionCommandStep.PASSWORD_ARG, PASSWORD)
-                .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, "/e2e/rename-property/changeLog-node-batched.${format}".toString())
+                .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, "/e2e/rename-property/changeLog-node-batched${if (concurrent) "-concurrent" else ""}.${format}".toString())
                 .setOutput(System.out)
         command.execute()
 
@@ -200,16 +210,19 @@ class RenamePropertyIT extends Neo4jContainerSpec {
         ]
 
         where:
-        format << ["json", "xml", "yaml"]
+        [format, concurrent] << [["json", "xml", "yaml"], [false, true]].combinations()
     }
 
     def "runs batched migrations renaming properties of rels only"() {
         given:
+        if (concurrent) {
+            assumeTrue(neo4jVersion() >= V5_21_0)
+        }
         def command = new CommandScope(UpdateCommandStep.COMMAND_NAME)
                 .addArgumentValue(DbUrlConnectionCommandStep.URL_ARG, "jdbc:neo4j:${neo4jContainer.getBoltUrl()}".toString())
                 .addArgumentValue(DbUrlConnectionCommandStep.USERNAME_ARG, "neo4j")
                 .addArgumentValue(DbUrlConnectionCommandStep.PASSWORD_ARG, PASSWORD)
-                .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, "/e2e/rename-property/changeLog-rel-batched.${format}".toString())
+                .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, "/e2e/rename-property/changeLog-rel-batched${if (concurrent) "-concurrent" else ""}.${format}".toString())
                 .setOutput(System.out)
         command.execute()
 
@@ -239,6 +252,6 @@ class RenamePropertyIT extends Neo4jContainerSpec {
         ]
 
         where:
-        format << ["json", "xml", "yaml"]
+        [format, concurrent] << [["json", "xml", "yaml"], [false, true]].combinations()
     }
 }

--- a/src/test/groovy/liquibase/ext/neo4j/e2e/RenameTypeIT.groovy
+++ b/src/test/groovy/liquibase/ext/neo4j/e2e/RenameTypeIT.groovy
@@ -6,6 +6,10 @@ import liquibase.command.core.helpers.DatabaseChangelogCommandStep
 import liquibase.command.core.helpers.DbUrlConnectionCommandStep
 import liquibase.ext.neo4j.Neo4jContainerSpec
 
+import static liquibase.ext.neo4j.DockerNeo4j.neo4jVersion
+import static liquibase.ext.neo4j.database.KernelVersion.V5_21_0
+import static org.junit.jupiter.api.Assumptions.assumeTrue
+
 class RenameTypeIT extends Neo4jContainerSpec {
 
     def "runs migrations renaming types"() {
@@ -48,11 +52,14 @@ class RenameTypeIT extends Neo4jContainerSpec {
 
     def "runs batched migrations renaming types"() {
         given:
+        if (concurrent) {
+            assumeTrue(neo4jVersion() >= V5_21_0)
+        }
         def command = new CommandScope(UpdateCommandStep.COMMAND_NAME)
                 .addArgumentValue(DbUrlConnectionCommandStep.URL_ARG, "jdbc:neo4j:${neo4jContainer.getBoltUrl()}".toString())
                 .addArgumentValue(DbUrlConnectionCommandStep.USERNAME_ARG, "neo4j")
                 .addArgumentValue(DbUrlConnectionCommandStep.PASSWORD_ARG, PASSWORD)
-                .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, "/e2e/rename-type/changeLog-simple-batched.${format}".toString())
+                .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, "/e2e/rename-type/changeLog-simple-batched${if (concurrent) "-concurrent" else ""}.${format}".toString())
                 .setOutput(System.out)
         command.execute()
 
@@ -81,7 +88,7 @@ class RenameTypeIT extends Neo4jContainerSpec {
         ]
 
         where:
-        format << ["json", "xml", "yaml"]
+        [format, concurrent] << [["json", "xml", "yaml"], [false, true]].combinations()
     }
 
     def "runs migrations renaming types of matching relationships"() {
@@ -123,11 +130,14 @@ class RenameTypeIT extends Neo4jContainerSpec {
 
     def "runs batched migrations renaming types of matching relationships"() {
         given:
+        if (concurrent) {
+            assumeTrue(neo4jVersion() >= V5_21_0)
+        }
         def command = new CommandScope(UpdateCommandStep.COMMAND_NAME)
                 .addArgumentValue(DbUrlConnectionCommandStep.URL_ARG, "jdbc:neo4j:${neo4jContainer.getBoltUrl()}".toString())
                 .addArgumentValue(DbUrlConnectionCommandStep.USERNAME_ARG, "neo4j")
                 .addArgumentValue(DbUrlConnectionCommandStep.PASSWORD_ARG, PASSWORD)
-                .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, "/e2e/rename-type/changeLog-pattern-batched.${format}".toString())
+                .addArgumentValue(DatabaseChangelogCommandStep.CHANGELOG_FILE_ARG, "/e2e/rename-type/changeLog-pattern-batched${if (concurrent) "-concurrent" else ""}.${format}".toString())
                 .setOutput(System.out)
         command.execute()
 
@@ -155,6 +165,6 @@ class RenameTypeIT extends Neo4jContainerSpec {
         ]
 
         where:
-        format << ["json", "xml", "yaml"]
+        [format, concurrent] << [["json", "xml", "yaml"], [false, true]].combinations()
     }
 }

--- a/src/test/resources/e2e/invert-direction/changeLog-pattern-batched-concurrent.json
+++ b/src/test/resources/e2e/invert-direction/changeLog-pattern-batched-concurrent.json
@@ -1,0 +1,37 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "my-movie-init-oops",
+        "author": "fbiville",
+        "changes": [
+          {
+            "cypher": "CREATE (:Movie)<-[:VIEWED_BY {date: 'now'}]-(:Person)"
+          },
+          {
+            "cypher": "CREATE (:Movie)-[:VIEWED_BY {date: 'yesterday'}]->(:Dog)"
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "my-movie-init-fixed",
+        "author": "fbiville",
+        "runInTransaction": false,
+        "changes": [
+          {
+            "invertDirection": {
+              "type": "VIEWED_BY",
+              "fragment": "(:Person)-[r:VIEWED_BY]->()",
+              "outputVariable": "r",
+              "enableBatchImport": true,
+              "batchSize": 1,
+              "concurrent": true
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/resources/e2e/invert-direction/changeLog-pattern-batched-concurrent.xml
+++ b/src/test/resources/e2e/invert-direction/changeLog-pattern-batched-concurrent.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:neo4j="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="my-movie-init-oops" author="fbiville">
+        <neo4j:cypher><![CDATA[CREATE (:Movie)<-[:VIEWED_BY {date: 'now'}]-(:Person)]]></neo4j:cypher>
+        <neo4j:cypher><![CDATA[CREATE (:Movie)-[:VIEWED_BY {date: 'yesterday'}]->(:Dog)]]></neo4j:cypher>
+    </changeSet>
+
+    <changeSet id="my-movie-init-fixed" author="fbiville" runInTransaction="false">
+        <neo4j:invertDirection type="VIEWED_BY" fragment="(:Person)-[r:VIEWED_BY]-&gt;()" outputVariable="r" enableBatchImport="true" batchSize="1" concurrent="true" />
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/resources/e2e/invert-direction/changeLog-pattern-batched-concurrent.yaml
+++ b/src/test/resources/e2e/invert-direction/changeLog-pattern-batched-concurrent.yaml
@@ -1,0 +1,19 @@
+databaseChangeLog:
+  - changeSet:
+      id: my-movie-init-oops
+      author: fbiville
+      changes:
+        - cypher: 'CREATE (:Movie)<-[:VIEWED_BY {date: ''now''}]-(:Person)'
+        - cypher: 'CREATE (:Movie)-[:VIEWED_BY {date: ''yesterday''}]->(:Dog)'
+  - changeSet:
+      id: my-movie-init-fixed
+      author: fbiville
+      runInTransaction: false
+      changes:
+        - invertDirection:
+            type: 'VIEWED_BY'
+            fragment: '(:Person)-[r:VIEWED_BY]->()'
+            outputVariable: 'r'
+            enableBatchImport: true
+            batchSize: 1
+            concurrent: true

--- a/src/test/resources/e2e/invert-direction/changeLog-simple-batched-concurrent.json
+++ b/src/test/resources/e2e/invert-direction/changeLog-simple-batched-concurrent.json
@@ -1,0 +1,35 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "my-movie-init-oops",
+        "author": "fbiville",
+        "changes": [
+          {
+            "cypher": "CREATE (:Movie)<-[:VIEWED_BY {date: 'now'}]-(:Person)"
+          },
+          {
+            "cypher": "CREATE (:Movie)<-[:VIEWED_BY {date: 'yesterday'}]-(:Dog)"
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "my-movie-init-fixed",
+        "author": "fbiville",
+        "runInTransaction": false,
+        "changes": [
+          {
+            "invertDirection": {
+              "type": "VIEWED_BY",
+              "enableBatchImport": true,
+              "batchSize": 1,
+              "concurrent": true
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/resources/e2e/invert-direction/changeLog-simple-batched-concurrent.xml
+++ b/src/test/resources/e2e/invert-direction/changeLog-simple-batched-concurrent.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:neo4j="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="my-movie-init-oops" author="fbiville">
+        <neo4j:cypher><![CDATA[CREATE (:Movie)<-[:VIEWED_BY {date: 'now'}]-(:Person)]]></neo4j:cypher>
+        <neo4j:cypher><![CDATA[CREATE (:Movie)<-[:VIEWED_BY {date: 'yesterday'}]-(:Dog)]]></neo4j:cypher>
+    </changeSet>
+
+    <changeSet id="my-movie-init-fixed" author="fbiville" runInTransaction="false">
+        <neo4j:invertDirection type="VIEWED_BY" enableBatchImport="true" batchSize="1" concurrent="true" />
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/resources/e2e/invert-direction/changeLog-simple-batched-concurrent.yaml
+++ b/src/test/resources/e2e/invert-direction/changeLog-simple-batched-concurrent.yaml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: my-movie-init-oops
+      author: fbiville
+      changes:
+        - cypher: 'CREATE (:Movie)<-[:VIEWED_BY {date: ''now''}]-(:Person)'
+        - cypher: 'CREATE (:Movie)<-[:VIEWED_BY {date: ''yesterday''}]-(:Dog)'
+  - changeSet:
+      id: my-movie-init-fixed
+      author: fbiville
+      runInTransaction: false
+      changes:
+        - invertDirection:
+            type: 'VIEWED_BY'
+            enableBatchImport: true
+            batchSize: 1
+            concurrent: true

--- a/src/test/resources/e2e/rename-label/changeLog-pattern-batched-concurrent.json
+++ b/src/test/resources/e2e/rename-label/changeLog-pattern-batched-concurrent.json
@@ -1,0 +1,38 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "my-movie-init-oops",
+        "author": "fbiville",
+        "changes": [
+          {
+            "cypher": "CREATE (:Movie {title: 'My Life', genre: 'Comedy'})"
+          },
+          {
+            "cypher": "CREATE (:Movie {title: 'My Birthday', genre: 'Musical'})"
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "my-movie-init-fixed",
+        "author": "fbiville",
+        "runInTransaction": false,
+        "changes": [
+          {
+            "renameLabel": {
+              "from": "Movie",
+              "to": "Film",
+              "fragment": "(m:Movie {title: 'My Birthday'})",
+              "outputVariable": "m",
+              "enableBatchImport": true,
+              "batchSize": 1,
+              "concurrent": true
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/resources/e2e/rename-label/changeLog-pattern-batched-concurrent.xml
+++ b/src/test/resources/e2e/rename-label/changeLog-pattern-batched-concurrent.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:neo4j="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="my-movie-init-oops" author="fbiville">
+        <neo4j:cypher>CREATE (:Movie {title: 'My Life', genre: 'Comedy'})</neo4j:cypher>
+        <neo4j:cypher>CREATE (:Movie {title: 'My Birthday', genre: 'Musical'})</neo4j:cypher>
+    </changeSet>
+
+    <changeSet id="my-movie-init-fixed" author="fbiville" runInTransaction="false">
+        <neo4j:renameLabel from="Movie" to="Film" fragment="(m:Movie {title: 'My Birthday'})" outputVariable="m" enableBatchImport="true" batchSize="1" concurrent="true" />
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/resources/e2e/rename-label/changeLog-pattern-batched-concurrent.yaml
+++ b/src/test/resources/e2e/rename-label/changeLog-pattern-batched-concurrent.yaml
@@ -1,0 +1,20 @@
+databaseChangeLog:
+  - changeSet:
+      id: my-movie-init-oops
+      author: fbiville
+      changes:
+        - cypher: 'CREATE (:Movie {title: ''My Life'', genre: ''Comedy''})'
+        - cypher: 'CREATE (:Movie {title: ''My Birthday'', genre: ''Musical''})'
+  - changeSet:
+      id: my-movie-init-fixed
+      author: fbiville
+      runInTransaction: false
+      changes:
+        - renameLabel:
+            from: 'Movie'
+            to: 'Film'
+            fragment: '(m:Movie {title: ''My Birthday''})'
+            outputVariable: 'm'
+            enableBatchImport: true
+            batchSize: 1
+            concurrent: true

--- a/src/test/resources/e2e/rename-label/changeLog-simple-batched-concurrent.json
+++ b/src/test/resources/e2e/rename-label/changeLog-simple-batched-concurrent.json
@@ -1,0 +1,36 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "my-movie-init-oops",
+        "author": "fbiville",
+        "changes": [
+          {
+            "cypher": "CREATE (:Movie {title: 'My Life', genre: 'Comedy'})"
+          },
+          {
+            "cypher": "CREATE (:Book {title: 'My Life', genre: 'Autobiography'})"
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "my-movie-init-fixed",
+        "author": "fbiville",
+        "runInTransaction": false,
+        "changes": [
+          {
+            "renameLabel": {
+              "from": "Movie",
+              "to": "Film",
+              "enableBatchImport": true,
+              "batchSize": 1,
+              "concurrent": true
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/resources/e2e/rename-label/changeLog-simple-batched-concurrent.xml
+++ b/src/test/resources/e2e/rename-label/changeLog-simple-batched-concurrent.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:neo4j="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="my-movie-init-oops" author="fbiville">
+        <neo4j:cypher>CREATE (:Movie {title: 'My Life', genre: 'Comedy'})</neo4j:cypher>
+        <neo4j:cypher>CREATE (:Book {title: 'My Life', genre: 'Autobiography'})</neo4j:cypher>
+    </changeSet>
+
+    <changeSet id="my-movie-init-fixed" author="fbiville" runInTransaction="false">
+        <neo4j:renameLabel from="Movie" to="Film" enableBatchImport="true" batchSize="1" concurrent="true" />
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/resources/e2e/rename-label/changeLog-simple-batched-concurrent.yaml
+++ b/src/test/resources/e2e/rename-label/changeLog-simple-batched-concurrent.yaml
@@ -1,0 +1,18 @@
+databaseChangeLog:
+  - changeSet:
+      id: my-movie-init-oops
+      author: fbiville
+      changes:
+        - cypher: 'CREATE (:Movie {title: ''My Life'', genre: ''Comedy''})'
+        - cypher: 'CREATE (:Book {title: ''My Life'', genre: ''Autobiography''})'
+  - changeSet:
+      id: my-movie-init-fixed
+      author: fbiville
+      runInTransaction: false
+      changes:
+        - renameLabel:
+            from: 'Movie'
+            to: 'Film'
+            enableBatchImport: true
+            batchSize: 1
+            concurrent: true

--- a/src/test/resources/e2e/rename-property/changeLog-all-batched-concurrent.json
+++ b/src/test/resources/e2e/rename-property/changeLog-all-batched-concurrent.json
@@ -1,0 +1,33 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "my-movie-init-oops",
+        "author": "fbiville",
+        "changes": [
+          {
+            "cypher": "CREATE (:Movie {calendar_date: 'today'})-[:SEEN_BY {calendar_date: 'now'}]->(:Person)"
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "my-movie-init-fixed",
+        "author": "fbiville",
+        "runInTransaction": false,
+        "changes": [
+          {
+            "renameProperty": {
+              "from": "calendar_date",
+              "to": "date",
+              "enableBatchImport": true,
+              "batchSize": 1,
+              "concurrent": true
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/resources/e2e/rename-property/changeLog-all-batched-concurrent.xml
+++ b/src/test/resources/e2e/rename-property/changeLog-all-batched-concurrent.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:neo4j="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="my-movie-init-oops" author="fbiville">
+        <neo4j:cypher><![CDATA[CREATE (:Movie {calendar_date: 'today'})-[:SEEN_BY {calendar_date: 'now'}]->(:Person)]]></neo4j:cypher>
+    </changeSet>
+
+    <changeSet id="my-movie-init-fixed" author="fbiville" runInTransaction="false">
+        <neo4j:renameProperty from="calendar_date" to="date" enableBatchImport="true" batchSize="1" concurrent="true" />
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/resources/e2e/rename-property/changeLog-all-batched-concurrent.yaml
+++ b/src/test/resources/e2e/rename-property/changeLog-all-batched-concurrent.yaml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: my-movie-init-oops
+      author: fbiville
+      changes:
+        - cypher: 'CREATE (:Movie {calendar_date: ''today''})-[:SEEN_BY {calendar_date: ''now''}]->(:Person)'
+  - changeSet:
+      id: my-movie-init-fixed
+      author: fbiville
+      runInTransaction: false
+      changes:
+        - renameProperty:
+            from: 'calendar_date'
+            to: 'date'
+            enableBatchImport: true
+            batchSize: 1
+            concurrent: true

--- a/src/test/resources/e2e/rename-property/changeLog-node-batched-concurrent.json
+++ b/src/test/resources/e2e/rename-property/changeLog-node-batched-concurrent.json
@@ -1,0 +1,34 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "my-movie-init-oops",
+        "author": "fbiville",
+        "changes": [
+          {
+            "cypher": "CREATE (:Movie {calendar_date: 'today'})-[:SEEN_BY {calendar_date: 'now'}]->(:Person)"
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "my-movie-init-fixed",
+        "author": "fbiville",
+        "runInTransaction": false,
+        "changes": [
+          {
+            "renameProperty": {
+              "from": "calendar_date",
+              "to": "date",
+              "entityType": "NODE",
+              "enableBatchImport": true,
+              "batchSize": 1,
+              "concurrent": true
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/resources/e2e/rename-property/changeLog-node-batched-concurrent.xml
+++ b/src/test/resources/e2e/rename-property/changeLog-node-batched-concurrent.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:neo4j="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="my-movie-init-oops" author="fbiville">
+        <neo4j:cypher><![CDATA[CREATE (:Movie {calendar_date: 'today'})-[:SEEN_BY {calendar_date: 'now'}]->(:Person)]]></neo4j:cypher>
+    </changeSet>
+
+    <changeSet id="my-movie-init-fixed" author="fbiville" runInTransaction="false">
+        <neo4j:renameProperty from="calendar_date" to="date" entityType="NODE" enableBatchImport="true" batchSize="1" concurrent="true" />
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/resources/e2e/rename-property/changeLog-node-batched-concurrent.yaml
+++ b/src/test/resources/e2e/rename-property/changeLog-node-batched-concurrent.yaml
@@ -1,0 +1,18 @@
+databaseChangeLog:
+  - changeSet:
+      id: my-movie-init-oops
+      author: fbiville
+      changes:
+        - cypher: 'CREATE (:Movie {calendar_date: ''today''})-[:SEEN_BY {calendar_date: ''now''}]->(:Person)'
+  - changeSet:
+      id: my-movie-init-fixed
+      author: fbiville
+      runInTransaction: false
+      changes:
+        - renameProperty:
+            from: 'calendar_date'
+            to: 'date'
+            entityType: 'NODE'
+            enableBatchImport: true
+            batchSize: 1
+            concurrent: true

--- a/src/test/resources/e2e/rename-property/changeLog-rel-batched-concurrent.json
+++ b/src/test/resources/e2e/rename-property/changeLog-rel-batched-concurrent.json
@@ -1,0 +1,34 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "my-movie-init-oops",
+        "author": "fbiville",
+        "changes": [
+          {
+            "cypher": "CREATE (:Movie {calendar_date: 'today'})-[:SEEN_BY {calendar_date: 'now'}]->(:Person)"
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "my-movie-init-fixed",
+        "author": "fbiville",
+        "runInTransaction": false,
+        "changes": [
+          {
+            "renameProperty": {
+              "from": "calendar_date",
+              "to": "date",
+              "entityType": "RELATIONSHIP",
+              "enableBatchImport": true,
+              "batchSize": 1,
+              "concurrent": true
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/resources/e2e/rename-property/changeLog-rel-batched-concurrent.xml
+++ b/src/test/resources/e2e/rename-property/changeLog-rel-batched-concurrent.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:neo4j="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="my-movie-init-oops" author="fbiville">
+        <neo4j:cypher><![CDATA[CREATE (:Movie {calendar_date: 'today'})-[:SEEN_BY {calendar_date: 'now'}]->(:Person)]]></neo4j:cypher>
+    </changeSet>
+
+    <changeSet id="my-movie-init-fixed" author="fbiville" runInTransaction="false">
+        <neo4j:renameProperty from="calendar_date" to="date" entityType="RELATIONSHIP" enableBatchImport="true" batchSize="1" concurrent="true" />
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/resources/e2e/rename-property/changeLog-rel-batched-concurrent.yaml
+++ b/src/test/resources/e2e/rename-property/changeLog-rel-batched-concurrent.yaml
@@ -1,0 +1,18 @@
+databaseChangeLog:
+  - changeSet:
+      id: my-movie-init-oops
+      author: fbiville
+      changes:
+        - cypher: 'CREATE (:Movie {calendar_date: ''today''})-[:SEEN_BY {calendar_date: ''now''}]->(:Person)'
+  - changeSet:
+      id: my-movie-init-fixed
+      author: fbiville
+      runInTransaction: false
+      changes:
+        - renameProperty:
+            from: 'calendar_date'
+            to: 'date'
+            entityType: 'RELATIONSHIP'
+            enableBatchImport: true
+            batchSize: 1
+            concurrent: true

--- a/src/test/resources/e2e/rename-type/changeLog-pattern-batched-concurrent.json
+++ b/src/test/resources/e2e/rename-type/changeLog-pattern-batched-concurrent.json
@@ -1,0 +1,38 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "my-movie-init-oops",
+        "author": "fbiville",
+        "changes": [
+          {
+            "cypher": "CREATE (:Movie)-[:SEEN_BY {date: 'now'}]->(:Person)"
+          },
+          {
+            "cypher": "CREATE (:Movie)-[:SEEN_BY {date: 'yesterday'}]->(:Dog)"
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "my-movie-init-fixed",
+        "author": "fbiville",
+        "runInTransaction": false,
+        "changes": [
+          {
+            "renameType": {
+              "from": "SEEN_BY",
+              "to": "VIEWED_BY",
+              "fragment": "(:Person)<-[r:SEEN_BY]-()",
+              "outputVariable": "r",
+              "enableBatchImport": true,
+              "batchSize": 1,
+              "concurrent": true
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/resources/e2e/rename-type/changeLog-pattern-batched-concurrent.xml
+++ b/src/test/resources/e2e/rename-type/changeLog-pattern-batched-concurrent.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:neo4j="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="my-movie-init-oops" author="fbiville">
+        <neo4j:cypher><![CDATA[CREATE (:Movie)-[:SEEN_BY {date: 'now'}]->(:Person)]]></neo4j:cypher>
+        <neo4j:cypher><![CDATA[CREATE (:Movie)-[:SEEN_BY {date: 'yesterday'}]->(:Dog)]]></neo4j:cypher>
+    </changeSet>
+
+    <changeSet id="my-movie-init-fixed" author="fbiville" runInTransaction="false">
+        <neo4j:renameType from="SEEN_BY" to="VIEWED_BY" fragment="(:Person)&lt;-[r:SEEN_BY]-()" outputVariable="r" enableBatchImport="true" batchSize="1" concurrent="true" />
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/resources/e2e/rename-type/changeLog-pattern-batched-concurrent.yaml
+++ b/src/test/resources/e2e/rename-type/changeLog-pattern-batched-concurrent.yaml
@@ -1,0 +1,20 @@
+databaseChangeLog:
+  - changeSet:
+      id: my-movie-init-oops
+      author: fbiville
+      changes:
+        - cypher: 'CREATE (:Movie)-[:SEEN_BY {date: ''now''}]->(:Person)'
+        - cypher: 'CREATE (:Movie)-[:SEEN_BY {date: ''yesterday''}]->(:Dog)'
+  - changeSet:
+      id: my-movie-init-fixed
+      author: fbiville
+      runInTransaction: false
+      changes:
+        - renameType:
+            from: 'SEEN_BY'
+            to: 'VIEWED_BY'
+            fragment: '(:Person)<-[r:SEEN_BY]-()'
+            outputVariable: 'r'
+            enableBatchImport: true
+            batchSize: 1
+            concurrent: true

--- a/src/test/resources/e2e/rename-type/changeLog-simple-batched-concurrent.json
+++ b/src/test/resources/e2e/rename-type/changeLog-simple-batched-concurrent.json
@@ -1,0 +1,36 @@
+{
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "my-movie-init-oops",
+        "author": "fbiville",
+        "changes": [
+          {
+            "cypher": "CREATE (:Movie)-[:SEEN_BY {date: 'now'}]->(:Person)"
+          },
+          {
+            "cypher": "CREATE (:Movie)-[:SEEN_BY {date: 'yesterday'}]->(:Dog)"
+          }
+        ]
+      }
+    },
+    {
+      "changeSet": {
+        "id": "my-movie-init-fixed",
+        "author": "fbiville",
+        "runInTransaction": false,
+        "changes": [
+          {
+            "renameType": {
+              "from": "SEEN_BY",
+              "to": "VIEWED_BY",
+              "enableBatchImport": true,
+              "batchSize": 1,
+              "concurrent": true
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/resources/e2e/rename-type/changeLog-simple-batched-concurrent.xml
+++ b/src/test/resources/e2e/rename-type/changeLog-simple-batched-concurrent.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:neo4j="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="my-movie-init-oops" author="fbiville">
+        <neo4j:cypher><![CDATA[CREATE (:Movie)-[:SEEN_BY {date: 'now'}]->(:Person)]]></neo4j:cypher>
+        <neo4j:cypher><![CDATA[CREATE (:Movie)-[:SEEN_BY {date: 'yesterday'}]->(:Dog)]]></neo4j:cypher>
+    </changeSet>
+
+    <changeSet id="my-movie-init-fixed" author="fbiville" runInTransaction="false">
+        <neo4j:renameType from="SEEN_BY" to="VIEWED_BY" enableBatchImport="true" batchSize="1" concurrent="true" />
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/resources/e2e/rename-type/changeLog-simple-batched-concurrent.yaml
+++ b/src/test/resources/e2e/rename-type/changeLog-simple-batched-concurrent.yaml
@@ -1,0 +1,18 @@
+databaseChangeLog:
+  - changeSet:
+      id: my-movie-init-oops
+      author: fbiville
+      changes:
+        - cypher: 'CREATE (:Movie)-[:SEEN_BY {date: ''now''}]->(:Person)'
+        - cypher: 'CREATE (:Movie)-[:SEEN_BY {date: ''yesterday''}]->(:Dog)'
+  - changeSet:
+      id: my-movie-init-fixed
+      author: fbiville
+      runInTransaction: false
+      changes:
+        - renameType:
+            from: 'SEEN_BY'
+            to: 'VIEWED_BY'
+            enableBatchImport: true
+            batchSize: 1
+            concurrent: true


### PR DESCRIPTION
This allows users running recent versions of Neo4j to get the benefits of `CALL {} IN CONCURRENT TRANSACTIONS` and/or `ON ERROR...` clauses for the changes that can currently run in batch:

- rename label
- rename type
- rename property
- invert direction