### PR TITLE
Fix nightly and dry-run workflows

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -2,11 +2,12 @@
 name: "Nightly build"
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 7 * * 1-5"
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   packages: read
 

--- a/.github/workflows/dry-run-release.yml
+++ b/.github/workflows/dry-run-release.yml
@@ -11,6 +11,7 @@ permissions:
   actions: read
   packages: write
   pull-requests: write
+  id-token: write
 
 jobs:
   dry-run-attach-artifact-to-release:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to enhance functionality and adjust permissions. The changes include enabling manual triggers for the nightly build workflow and modifying permissions in both the nightly build and dry-run release workflows.

Workflow functionality updates:

* [`.github/workflows/build-nightly.yml`](diffhunk://#diff-9af00ec87e110684f20ae5b6b3bd168ad21793f9dfe9946c9c48587fdd6ef1f6R5-R10): Added `workflow_dispatch` to allow manual triggering of the nightly build workflow.

Permission adjustments:

* [`.github/workflows/build-nightly.yml`](diffhunk://#diff-9af00ec87e110684f20ae5b6b3bd168ad21793f9dfe9946c9c48587fdd6ef1f6R5-R10): Changed `contents` permission from `read` to `write` to allow modifications to repository contents during the workflow.
* [`.github/workflows/dry-run-release.yml`](diffhunk://#diff-da505eba40e5178912154d1d165e17f3353098ba24e44bd62d23ad028700e42aR14): Added `id-token: write` permission to enable workflows to authenticate with GitHub services or external systems.