### PR TITLE
Fix e2e nightly builds

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -49,6 +49,49 @@ jobs:
           distribution: "temurin"
           cache: "maven"
 
+      # look for dependencies in maven
+      - name: maven-settings-xml-action
+        uses: whelk-io/maven-settings-xml-action@v22
+        with:
+          repositories: |
+            [
+              {
+                "id": "liquibase",
+                "url": "https://maven.pkg.github.com/liquibase/liquibase",
+                "releases": {
+                  "enabled": "true"
+                },
+                "snapshots": {
+                  "enabled": "true",
+                  "updatePolicy": "always"
+                }
+              },
+              {
+                "id": "liquibase-pro",
+                "url": "https://maven.pkg.github.com/liquibase/liquibase-pro",
+                "releases": {
+                  "enabled": "true"
+                },
+                "snapshots": {
+                  "enabled": "true",
+                  "updatePolicy": "always"
+                }
+              }
+            ]
+          servers: |
+            [
+              {
+                "id": "liquibase-pro",
+                "username": "liquibot",
+                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
+              },
+              {
+                "id": "liquibase",
+                "username": "liquibot",
+                "password": "${{ secrets.LIQUIBOT_PAT_GPM_ACCESS }}"
+              }
+            ]
+
       - name: Run Tests
         run: mvn --quiet --show-version --batch-mode verify -Dliquibase.version="master-SNAPSHOT"
         env:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for nightly builds by adding a new step to configure Maven settings. This change ensures that dependencies are fetched from the appropriate repositories with proper authentication.

### Workflow improvements:

* [`.github/workflows/build-nightly.yml`](diffhunk://#diff-9af00ec87e110684f20ae5b6b3bd168ad21793f9dfe9946c9c48587fdd6ef1f6R52-R94): Added a new step using the `whelk-io/maven-settings-xml-action` to configure Maven repositories and authentication. This includes defining repositories for `liquibase` and `liquibase-pro`, as well as setting up credentials using GitHub secrets.