### PR TITLE
DAT-20612: test extension-attach-artifact-release.yml

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     types:
       - closed
-
+  workflow_dispatch:
+  
 permissions:
   contents: write
   actions: read


### PR DESCRIPTION
This pull request introduces a small change to the GitHub Actions workflow configuration by enabling manual triggering of the `attach-artifact-release.yml` workflow. This allows users to run the workflow on demand via the GitHub Actions UI.

* Added `workflow_dispatch` to the `on:` section in `.github/workflows/attach-artifact-release.yml` to support manual workflow runs.