### PR TITLE
TECHOPS-147: replace archived jakejarvis/s3-sync-action with AWS CLI

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -25,14 +25,15 @@ jobs:
           docker build --file documentation.Dockerfile --tag liquibase/neo4j-docs:latest .
           docker run --pull never --volume "$(pwd)":/usr/src/app liquibase/neo4j-docs:latest build
 
-      - name: Sync to Static
-        uses: jakejarvis/s3-sync-action@be0c4ab89158cac4278689ebedd8407dd5f35a83 # v0.5.1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
-          args: --acl public-read --follow-symlinks
+          aws-access-key-id: ${{ secrets.NEO4J_DOCS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.NEO4J_DOCS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.NEO4J_DOCS_S3_REGION }}
+
+      - name: Sync to Static
         env:
           AWS_S3_BUCKET: ${{ secrets.NEO4J_DOCS_S3_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.NEO4J_DOCS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.NEO4J_DOCS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.NEO4J_DOCS_S3_REGION }}
-          SOURCE_DIR: 'site/'
-          DEST_DIR: 'labs/liquibase/docs'
+        run: |
+          aws s3 sync site/ "s3://${AWS_S3_BUCKET}/labs/liquibase/docs" --acl public-read --follow-symlinks


### PR DESCRIPTION
## Summary

Replace `jakejarvis/s3-sync-action@v0.5.1` (archived 2025-01-18) in `.github/workflows/documentation.yml` with the direct `aws s3 sync` CLI invocation, fronted by AWS's `aws-actions/configure-aws-credentials` to bring the existing static keys into the runner environment.

Resolves [TECHOPS-147](https://datical.atlassian.net/browse/TECHOPS-147), unblocks the DAT-22654 archived-action allowlist cleanup.

## Why

- `jakejarvis/s3-sync-action` is archived ([repo](https://github.com/jakejarvis/s3-sync-action) — last release v0.5.1 from 2020-01-14). No security fixes will ship.
- The action is a thin wrapper around `aws s3 sync` — the AWS CLI is preinstalled on `ubuntu-latest`, so the migration drops a third-party dependency without losing functionality.
- Pattern matches existing usage in `liquibase/liquibase/.github/workflows/release-deploy-xsd.yml` and similar (AWS verified-publisher actions + raw CLI).

## What changed

`.github/workflows/documentation.yml` only — the "Sync to Static" step:

| Before | After |
|---|---|
| `uses: jakejarvis/s3-sync-action@be0c4ab… # v0.5.1` with `args:` + env-var passthrough | `aws-actions/configure-aws-credentials@ec61189… # v6.1.0` (verified publisher) + `run: aws s3 sync …` |

Auth model unchanged (same `secrets.NEO4J_DOCS_*` static keys). Source (`site/`), destination (`s3://${BUCKET}/labs/liquibase/docs`), and sync flags (`--acl public-read --follow-symlinks`) all preserved.

## Out of scope (intentional)

- **Full OIDC migration** — replacing static `NEO4J_DOCS_ACCESS_KEY_ID`/`_SECRET_ACCESS_KEY` with an OIDC-assumed IAM role. That's a separate hardening concern that requires creating an IAM role in the AWS account that owns the docs bucket. TECHOPS-147 is scoped to "remove the archived action".

## Test plan

- [ ] PR build / actionlint passes
- [ ] After merge, manually trigger `Publish docs` workflow (or push a doc change) on `main` and confirm:
  - `Configure AWS credentials` step succeeds
  - `Sync to Static` step uploads the rendered `site/` to `s3://${NEO4J_DOCS_S3_BUCKET}/labs/liquibase/docs` with the same files as before
  - Public docs URL reflects the published content
- [ ] Remove `jakejarvis/s3-sync-action@*` from the DAT-22654 allowlist candidate list

## References

- Jira: [TECHOPS-147](https://datical.atlassian.net/browse/TECHOPS-147)
- Parent story: [DAT-21269](https://datical.atlassian.net/browse/DAT-21269)
- Blocks: [DAT-22654](https://datical.atlassian.net/browse/DAT-22654)
- Archived action notice: https://github.com/jakejarvis/s3-sync-action

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TECHOPS-147]: https://datical.atlassian.net/browse/TECHOPS-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECHOPS-147]: https://datical.atlassian.net/browse/TECHOPS-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ