### PR TITLE
ci: grant actions:read in release-published workflow

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -10,7 +10,8 @@ permissions:
   pull-requests: write
   packages: write
   id-token: write
-  
+  actions: read # required by the reusable workflow's "Get build-logic ref" step
+
 jobs:
   release:
     uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@main


### PR DESCRIPTION
## Problem

The v5.0.2 release workflow (`Release Extension to Sonatype`) ended in a `startup_failure` with **zero jobs run** — GitHub refused to compile it before anything started. The actual error:

> Invalid workflow file: .github/workflows/release-published.yml#L15
> Error calling workflow 'liquibase/build-logic/.github/workflows/extension-release-published.yml@main'. The workflow is requesting 'actions: read', but is only allowed 'actions: none'.

## Cause

`extension-release-published.yml@main` now requests `actions: read` (added in build-logic to let its "Get build-logic ref" step query the Actions API). This caller declares an explicit `permissions:` block, and once a block is explicit every unlisted scope defaults to `none`. A called reusable workflow cannot be granted more than its caller holds, so GitHub rejects the workflow at compile time.

## Fix

Add `actions: read` to the caller's `permissions:` block. The other build-logic-calling workflows in this repo (`attach-artifact-release.yml`, `create-release.yml`) already carry this scope; `release-published.yml` was the one that got missed.

## Note

This does not retroactively run the v5.0.2 release — that run is already dead. After merge, v5.0.2 will need to be re-triggered (manual `workflow_dispatch`, or delete & re-publish the release).