### PR TITLE
ci: grant id-token write in create-release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -12,7 +12,8 @@ permissions:
   statuses: read
   actions: read
   security-events: write
-  
+  id-token: write # Required by AWS OIDC authentication in sonar
+
 jobs:
   create-release:
     uses: liquibase/build-logic/.github/workflows/create-release.yml@main


### PR DESCRIPTION
Create Release never ran, every push to main ends in startup_failure:
https://github.com/liquibase/liquibase-neo4j/actions/runs/32366920159

The reusable workflow calls sonar-scan.yml, which needs id-token: write for the
AWS OIDC step. Without it the nested job gets id-token: none and the run is
aborted before any job starts. The same permission is already in mongodb,
bigquery, cassandra, cache and hanadb.